### PR TITLE
Convert tabs to spaces

### DIFF
--- a/src/PostalCodes.UnitTests/CountryPostalCodeTests.cs
+++ b/src/PostalCodes.UnitTests/CountryPostalCodeTests.cs
@@ -6,7 +6,7 @@ namespace PostalCodes.Contracts.UnitTests
     [TestFixture]
     internal class CountryPostalCodeTests
     {
-		#pragma warning disable 0414
+        #pragma warning disable 0414
         private static readonly object[] DataSourceForEqualOperator =
         {
             new object[] {"BG", "1000", "BG", "1000", true}, new object[] {"BG", "1000", "BG", null, false},
@@ -23,7 +23,7 @@ namespace PostalCodes.Contracts.UnitTests
             new object[] {"US", null, "BG", null, 1}, new object[] {"BG", null, "GB", null, -1}, new object[] {"BG", null, "BG", null, 0},
             new object[] {"US", null, "BG", null, 1}, new object[] {"US", "1000", "US", null, 1}, new object[] {"US", null, "US", "1000", -1},
         };
-		#pragma warning restore 0414
+        #pragma warning restore 0414
 
         [Test, TestCaseSource("DataSourceForEqualOperator")]
         public void OperatorEquals(string country1, string code1, string country2, string code2, bool expectedResult)

--- a/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/BBPostalCodeManualTests.cs
+++ b/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/BBPostalCodeManualTests.cs
@@ -6,14 +6,14 @@ namespace PostalCodes.UnitTests.CountrySpecificPostalCodes
     internal class BBPostalCodeManualTests
     {
         [TestCase("BB12345", "12344")]
-		[TestCase("12345", "12344")]
-		public void Predecessor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodePredecessor)
+        [TestCase("12345", "12344")]
+        public void Predecessor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodePredecessor)
         {
             Assert.AreEqual(postalCodePredecessor, (new BBPostalCode(postalCode)).Predecessor.ToString());
         }
 
-		[TestCase("BB12345", "12346")]
-		[TestCase("12345", "12346")]
+        [TestCase("BB12345", "12346")]
+        [TestCase("12345", "12346")]
         public void Successor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodeSuccessor)
         {
             Assert.AreEqual(postalCodeSuccessor, (new BBPostalCode(postalCode)).Successor.ToString());

--- a/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/CAPostalCodeManualTests.cs
+++ b/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/CAPostalCodeManualTests.cs
@@ -3,7 +3,7 @@
 namespace PostalCodes.UnitTests.CountrySpecificPostalCodes
 {
     [TestFixture]
-	internal class CAPostalCodeManualTests
+    internal class CAPostalCodeManualTests
     {
         [Test]
         [TestCase("A0A0A1", "A0A0A0")]        

--- a/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/GBPostalCodeManualTests.cs
+++ b/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/GBPostalCodeManualTests.cs
@@ -3,7 +3,7 @@
 namespace PostalCodes.UnitTests.CountrySpecificPostalCodes
 {
     [TestFixture]
-	internal class GBPostalCodeManualTests
+    internal class GBPostalCodeManualTests
     {
         [Test]
         [TestCase("AA9A 9", "AA9A8")]

--- a/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/MTPostalCodeManualTests.cs
+++ b/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/MTPostalCodeManualTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace PostalCodes.UnitTests.CountrySpecificPostalCodes
 {
     [TestFixture]
-	internal class MTPostalCodeManualTests
+    internal class MTPostalCodeManualTests
     {
         [TestCase("PLA123")]
         [TestCase("PL1234")]

--- a/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/NLPostalCodeManualTests.cs
+++ b/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/NLPostalCodeManualTests.cs
@@ -3,7 +3,7 @@
 namespace PostalCodes.UnitTests.CountrySpecificPostalCodes
 {
     [TestFixture]
-	internal class NLPostalCodeManualTests
+    internal class NLPostalCodeManualTests
     {
         [Test]
         [TestCase("9992 ZZ", "9991")]

--- a/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/PTPostalCodeManualTests.cs
+++ b/src/PostalCodes.UnitTests/CountrySpecificPostalCodes/PTPostalCodeManualTests.cs
@@ -2,16 +2,16 @@
 namespace PostalCodes.UnitTests.CountrySpecificPostalCodes
 {
     [TestFixture]
-	internal class PTPostalCodeManualTests
+    internal class PTPostalCodeManualTests
     {
         [Test]
         [TestCase("2660", "2659999")]
         [TestCase("2660023", "2660022")]
         public void Predecessor_ValidInputWithStart_ReturnsCorrectPostalCode(string postalCode, string postalCodePredecessor)
         {
-			var code = new PTPostalCode (postalCode);
-			var expansion = code.ExpandPostalCodeAsLowestInRange ();
-			Assert.AreEqual(postalCodePredecessor, expansion.Predecessor.ToString());
+            var code = new PTPostalCode (postalCode);
+            var expansion = code.ExpandPostalCodeAsLowestInRange ();
+            Assert.AreEqual(postalCodePredecessor, expansion.Predecessor.ToString());
         }
 
         [Test]
@@ -19,9 +19,9 @@ namespace PostalCodes.UnitTests.CountrySpecificPostalCodes
         [TestCase("2660023", "2660022")]
         public void Predecessor_ValidInputWithEnd_ReturnsCorrectPostalCode(string postalCode, string postalCodePredecessor)
         {
-			var code = new PTPostalCode (postalCode);
-			var expansion = code.ExpandPostalCodeAsHighestInRange ();
-			Assert.AreEqual(postalCodePredecessor, expansion.Predecessor.ToString());
+            var code = new PTPostalCode (postalCode);
+            var expansion = code.ExpandPostalCodeAsHighestInRange ();
+            Assert.AreEqual(postalCodePredecessor, expansion.Predecessor.ToString());
         }
 
         [Test]
@@ -29,9 +29,9 @@ namespace PostalCodes.UnitTests.CountrySpecificPostalCodes
         [TestCase("2660023", "2660024")]
         public void Successor_ValidInputWithStart_ReturnsCorrectPostalCode(string postalCode, string postalCodeSuccessor)
         {
-			var code = new PTPostalCode (postalCode);
-			var expansion = code.ExpandPostalCodeAsLowestInRange ();
-			Assert.AreEqual(postalCodeSuccessor, expansion.Successor.ToString());
+            var code = new PTPostalCode (postalCode);
+            var expansion = code.ExpandPostalCodeAsLowestInRange ();
+            Assert.AreEqual(postalCodeSuccessor, expansion.Successor.ToString());
         }
 
         [Test]
@@ -39,9 +39,9 @@ namespace PostalCodes.UnitTests.CountrySpecificPostalCodes
         [TestCase("2660023", "2660024")]
         public void Successor_ValidInputWithEnd_ReturnsCorrectPostalCode(string postalCode, string postalCodeSuccessor)
         {
-			var code = new PTPostalCode (postalCode);
-			var expansion = code.ExpandPostalCodeAsHighestInRange ();
-			Assert.AreEqual(postalCodeSuccessor, expansion.Successor.ToString());
+            var code = new PTPostalCode (postalCode);
+            var expansion = code.ExpandPostalCodeAsHighestInRange ();
+            Assert.AreEqual(postalCodeSuccessor, expansion.Successor.ToString());
         }
 
         [Test]
@@ -49,27 +49,27 @@ namespace PostalCodes.UnitTests.CountrySpecificPostalCodes
         [TestCase("0000000")]
         public void Predecessor_FirstInRangeWithStart_ReturnsNull(string postalCode)
         {
-			var code = new PTPostalCode (postalCode);
-			var expansion = code.ExpandPostalCodeAsLowestInRange ();
-			Assert.IsNull(expansion.Predecessor);
+            var code = new PTPostalCode (postalCode);
+            var expansion = code.ExpandPostalCodeAsLowestInRange ();
+            Assert.IsNull(expansion.Predecessor);
         }
 
         [Test]
         [TestCase("0000000")]
         public void Predecessor_FirstInRangeWithEnd_ReturnsNull(string postalCode)
         {
-			var code = new PTPostalCode (postalCode);
-			var expansion = code.ExpandPostalCodeAsHighestInRange ();
-			Assert.IsNull(expansion.Predecessor);
+            var code = new PTPostalCode (postalCode);
+            var expansion = code.ExpandPostalCodeAsHighestInRange ();
+            Assert.IsNull(expansion.Predecessor);
         }
 
         [Test]
         [TestCase("9999999")]
         public void Successor_LastInRangeWithStart_ReturnsNull(string postalCode)
         {
-			var code = new PTPostalCode (postalCode);
-			var expansion = code.ExpandPostalCodeAsLowestInRange ();
-			Assert.IsNull(expansion.Successor);
+            var code = new PTPostalCode (postalCode);
+            var expansion = code.ExpandPostalCodeAsLowestInRange ();
+            Assert.IsNull(expansion.Successor);
         }
 
         [Test]
@@ -77,16 +77,16 @@ namespace PostalCodes.UnitTests.CountrySpecificPostalCodes
         [TestCase("9999999")]
         public void Successor_LastInRangeWithEnd_ReturnsNull(string postalCode)
         {
-			var code = new PTPostalCode (postalCode);
-			var expansion = code.ExpandPostalCodeAsHighestInRange ();
-			Assert.IsNull(expansion.Successor);
+            var code = new PTPostalCode (postalCode);
+            var expansion = code.ExpandPostalCodeAsHighestInRange ();
+            Assert.IsNull(expansion.Successor);
         }
 
         [Test]
         public void Predecessor_ValidInput_ReturnsPortugalPostalCodeObject()
         {
-			var code = new PTPostalCode ("1234");
-			var x = code.Predecessor;
+            var code = new PTPostalCode ("1234");
+            var x = code.Predecessor;
             Assert.IsTrue(x.GetType() == typeof(PTPostalCode));
         }
 

--- a/src/PostalCodes.UnitTests/CountryTests.cs
+++ b/src/PostalCodes.UnitTests/CountryTests.cs
@@ -6,7 +6,7 @@ namespace PostalCodes.UnitTests
     [TestFixture]
     internal class CountryTests
     {
-		#pragma warning disable 0414
+        #pragma warning disable 0414
         private static readonly object[] DataSourceForEqualOperator =
         {
             new object[] {"BG", "BG",  true}, 
@@ -22,7 +22,7 @@ namespace PostalCodes.UnitTests
             var cp2 = new Country(country2);
             Assert.AreEqual(expectedResult, cp1 == cp2);
         }
-		#pragma warning restore 0414
+        #pragma warning restore 0414
 
         [Test, TestCaseSource("DataSourceForEqualOperator")]
         public void Country_Equals_ReturnsCorrectResult(string country1, string country2, bool expectedResult)

--- a/src/PostalCodes.UnitTests/DefaultPostalCodeTests.cs
+++ b/src/PostalCodes.UnitTests/DefaultPostalCodeTests.cs
@@ -28,42 +28,42 @@ namespace PostalCodes.UnitTests
         [TestCase("3452", "3453")]
         public void Successor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodeSuccessor)
         {
-			Assert.AreEqual(postalCodeSuccessor, (new DefaultPostalCode(postalCode)).Successor.ToString());
+            Assert.AreEqual(postalCodeSuccessor, (new DefaultPostalCode(postalCode)).Successor.ToString());
         }
         
         [Test]
         [TestCase("00000")]
         public void Predecessor_FirstInRange_ReturnsNull(string postalCode)
         {
-			Assert.IsNull((new DefaultPostalCode(postalCode)).Predecessor);
+            Assert.IsNull((new DefaultPostalCode(postalCode)).Predecessor);
         }
 
         [Test]
         [TestCase("99999")]
         public void Successor_LastInRange_ReturnsNull(string postalCode)
         {
-			Assert.IsNull((new DefaultPostalCode(postalCode)).Successor);
+            Assert.IsNull((new DefaultPostalCode(postalCode)).Successor);
         }
 
         [Test]
         [TestCase("999x99")]
         public void Constructor_InvalidNumber_ThrowsFormatException(string postalCode)
         {
-			Assert.Throws<ArgumentException>( () => new DefaultPostalCode(postalCode));
+            Assert.Throws<ArgumentException>( () => new DefaultPostalCode(postalCode));
         }
 
         [Test]
         public void Predecessor_ValidInput_ReturnsNumericPostalCodeObject()
         {
-			var x = (new DefaultPostalCode("444")).Predecessor;
-			Assert.IsTrue(x.GetType() == typeof(DefaultPostalCode));
+            var x = (new DefaultPostalCode("444")).Predecessor;
+            Assert.IsTrue(x.GetType() == typeof(DefaultPostalCode));
         }
 
         [Test]
         public void Successor_ValidInput_ReturnsNumericPostalCodeObject()
         {
-			var x = (new DefaultPostalCode("444")).Successor;
-			Assert.IsTrue(x.GetType() == typeof(DefaultPostalCode));
+            var x = (new DefaultPostalCode("444")).Successor;
+            Assert.IsTrue(x.GetType() == typeof(DefaultPostalCode));
         }
     }
 }

--- a/src/PostalCodes.UnitTests/IsoCountryCodeConverterTests.cs
+++ b/src/PostalCodes.UnitTests/IsoCountryCodeConverterTests.cs
@@ -3,18 +3,18 @@ using NUnit.Framework;
 
 namespace PostalCodes.UnitTests
 {
-	internal class IsoCountryCodeConverterTests
+    internal class IsoCountryCodeConverterTests
     {
-		private static readonly IsoCountryCodeConverter IsoConverter = new IsoCountryCodeConverter();
+        private static readonly IsoCountryCodeConverter IsoConverter = new IsoCountryCodeConverter();
 
         [Test]
         [TestCase("GB", "UK")]
         [TestCase("BQ", "AN")]
         [TestCase("SX", "AN")]
         [TestCase("CW", "AN")]
-		public void GetIso3166p3Code_WithIso3166p1Code_ReturnsIso3166p3Code(string input, string output)
+        public void GetIso3166p3Code_WithIso3166p1Code_ReturnsIso3166p3Code(string input, string output)
         {
-			Assert.AreEqual(output, IsoConverter.GetIso3166p3Code(input));
+            Assert.AreEqual(output, IsoConverter.GetIso3166p3Code(input));
         }
 
         [Test]
@@ -22,9 +22,9 @@ namespace PostalCodes.UnitTests
         [TestCase("BM")]
         [TestCase("CA")]
         [TestCase("DE")]
-		public void GetIso3166p3Code_WithIso3166p1Code_ReturnsIso3166p1Code(string input)
+        public void GetIso3166p3Code_WithIso3166p1Code_ReturnsIso3166p1Code(string input)
         {
-			Assert.AreEqual(input, IsoConverter.GetIso3166p3Code(input));
+            Assert.AreEqual(input, IsoConverter.GetIso3166p3Code(input));
         }
 
         [Test]
@@ -32,9 +32,9 @@ namespace PostalCodes.UnitTests
         [TestCase("KJ")]
         [TestCase("IY")]
         [TestCase("ZU")]
-		public void GetIso3166p3Code_WithUnassignedUserDefinedOrNotUsedCode_ThrowsInvalidOperationException(string input)
+        public void GetIso3166p3Code_WithUnassignedUserDefinedOrNotUsedCode_ThrowsInvalidOperationException(string input)
         {
-			Assert.Throws<InvalidOperationException>(() => IsoConverter.GetIso3166p3Code(input));
+            Assert.Throws<InvalidOperationException>(() => IsoConverter.GetIso3166p3Code(input));
         }
     }
 }

--- a/src/PostalCodes.UnitTests/PostalCodeFactoryTests.cs
+++ b/src/PostalCodes.UnitTests/PostalCodeFactoryTests.cs
@@ -9,7 +9,7 @@ namespace PostalCodes.UnitTests
         [Test]
         [TestCase("GB", "A1 9ZZ", "A19", "GBPostalCode")]
         [TestCase("PT", "0042", "0042", "PTPostalCode")]
-		[TestCase("CA", "A9A9A9", "A9A9A9", "CAPostalCode")]
+        [TestCase("CA", "A9A9A9", "A9A9A9", "CAPostalCode")]
         [TestCase("NL", "0024 ZZ", "0024", "NLPostalCode")]
         [TestCase("MT", "PLA1234", "PLA1234", "MTPostalCode")]
         [TestCase("??", "004", "004", "DefaultPostalCode")]

--- a/src/PostalCodes.UnitTests/PostalCodeRangeTests.cs
+++ b/src/PostalCodes.UnitTests/PostalCodeRangeTests.cs
@@ -11,7 +11,7 @@ namespace PostalCodes.UnitTests
         private static PostalCodeRange MakeRange(string start, string end)
         {
             var startPc = start != null ? new DefaultPostalCode(start) : null;
-			var endPc = end != null ? new DefaultPostalCode(end) : null;
+            var endPc = end != null ? new DefaultPostalCode(end) : null;
             return new PostalCodeRange(startPc, endPc);
         }
 
@@ -55,7 +55,7 @@ namespace PostalCodes.UnitTests
         public void Ctor_with_args_sets_start_and_end()
         {
             var start = new DefaultPostalCode("12345");
-			var end = new DefaultPostalCode("67890");
+            var end = new DefaultPostalCode("67890");
 
             var range = new PostalCodeRange(start, end);
 
@@ -76,8 +76,8 @@ namespace PostalCodes.UnitTests
             get
             {
                 yield return new TestCaseData(null, null);
-				yield return new TestCaseData(new DefaultPostalCode("ABCDE"), new DefaultPostalCode("FGHIJ"));
-				yield return new TestCaseData(new DefaultPostalCode("02421"), new DefaultPostalCode("12958"));
+                yield return new TestCaseData(new DefaultPostalCode("ABCDE"), new DefaultPostalCode("FGHIJ"));
+                yield return new TestCaseData(new DefaultPostalCode("02421"), new DefaultPostalCode("12958"));
             }
         }
 
@@ -423,8 +423,8 @@ namespace PostalCodes.UnitTests
         [Test]
         public void AreOverlapping_1()
         {
-			var left = new PostalCodeRange(new DefaultPostalCode("1000"), new DefaultPostalCode("2000"));
-			var right = new PostalCodeRange(new DefaultPostalCode("1500"), new DefaultPostalCode("2500"));
+            var left = new PostalCodeRange(new DefaultPostalCode("1000"), new DefaultPostalCode("2000"));
+            var right = new PostalCodeRange(new DefaultPostalCode("1500"), new DefaultPostalCode("2500"));
 
             Assert.IsTrue(PostalCodeRange.AreOverlapping(left, right));
         }

--- a/src/PostalCodes.UnitTests/PostalCodeTests.cs
+++ b/src/PostalCodes.UnitTests/PostalCodeTests.cs
@@ -9,8 +9,8 @@ namespace PostalCodes.UnitTests
         [Test]
         public void PostalCode_OperatorLessThanGreaterThan()
         {
-			var p1 = new DefaultPostalCode("1000");
-			var p2 = new DefaultPostalCode("1001");
+            var p1 = new DefaultPostalCode("1000");
+            var p2 = new DefaultPostalCode("1001");
             Assert.IsTrue(p1 < p2);
             Assert.IsFalse(p2 < p1);
 
@@ -33,8 +33,8 @@ namespace PostalCodes.UnitTests
         public void PostalCode_Equals()
         {
             var p1 = new DefaultPostalCode("1000"); 
-			var p11 = new DefaultPostalCode("1000");
-			var p2 = new DefaultPostalCode("1001");
+            var p11 = new DefaultPostalCode("1000");
+            var p2 = new DefaultPostalCode("1001");
 
             Assert.IsFalse(p1.Equals((object)p2));
             Assert.IsFalse(p2.Equals((object)p1));

--- a/src/PostalCodes/GenericPostalCodes/AlphaNumericPostalCode.cs
+++ b/src/PostalCodes/GenericPostalCodes/AlphaNumericPostalCode.cs
@@ -2,28 +2,28 @@
 
 namespace PostalCodes.GenericPostalCodes
 {
-	internal abstract class AlphaNumericPostalCode : PostalCode
+    internal abstract class AlphaNumericPostalCode : PostalCode
     {
-		internal AlphaNumericPostalCode(PostalCodeFormat[] formats, string postalCode) : this(formats, postalCode, true) {}
+        internal AlphaNumericPostalCode(PostalCodeFormat[] formats, string postalCode) : this(formats, postalCode, true) {}
 
-		internal AlphaNumericPostalCode(PostalCodeFormat[] formats, string postalCode, bool allowConvertToShort) : base(formats, postalCode, allowConvertToShort) {}
+        internal AlphaNumericPostalCode(PostalCodeFormat[] formats, string postalCode, bool allowConvertToShort) : base(formats, postalCode, allowConvertToShort) {}
 
 
-		/// <summary>
-		/// Gets the internal value.
-		/// </summary>
-		/// <returns>The internal value.</returns>
-		protected string GetInternalValue() {
-			return PostalCodeString;
-		}
+        /// <summary>
+        /// Gets the internal value.
+        /// </summary>
+        /// <returns>The internal value.</returns>
+        protected string GetInternalValue() {
+            return PostalCodeString;
+        }
 
-		/// <summary>
-		/// Generates the succesor or predecessor.
-		/// </summary>
-		/// <returns>The succesor or predecessor.</returns>
-		/// <param name="postalCode">Postal code.</param>
-		/// <param name="getSuccessor">If set to <c>true</c> get successor.</param>
-		protected string GenerateSuccesorOrPredecessor(string postalCode, bool getSuccessor)
+        /// <summary>
+        /// Generates the succesor or predecessor.
+        /// </summary>
+        /// <returns>The succesor or predecessor.</returns>
+        /// <param name="postalCode">Postal code.</param>
+        /// <param name="getSuccessor">If set to <c>true</c> get successor.</param>
+        protected string GenerateSuccesorOrPredecessor(string postalCode, bool getSuccessor)
         {
             var nextTriggerNumber = getSuccessor ? '9' : '0';
             var nextTriggerLetter = getSuccessor ? 'Z' : 'A';
@@ -51,7 +51,7 @@ namespace PostalCodes.GenericPostalCodes
             var newChar = (char) (postalCode[radix] + (getSuccessor ? 1 : -1));
             var nextPostalCode = postalCode.Substring(0, radix) + newChar + suffix;
             
-			return nextPostalCode;
+            return nextPostalCode;
         }
     }
 }

--- a/src/PostalCodes/GenericPostalCodes/NumericPostalCode.cs
+++ b/src/PostalCodes/GenericPostalCodes/NumericPostalCode.cs
@@ -8,7 +8,7 @@ namespace PostalCodes
         private readonly int MaxPostalCodeInt;
         private readonly int PostalCodeLength;
 
-		public NumericPostalCode(PostalCodeFormat[] formats, string postalCode) : base(formats, postalCode)
+        public NumericPostalCode(PostalCodeFormat[] formats, string postalCode) : base(formats, postalCode)
         {
         }
 
@@ -16,8 +16,8 @@ namespace PostalCodes
         {
             get
             {
-				var prev = GenerateSuccesorOrPredecessor (GetInternalValue (), false);
-				return (prev == null) ? null : new NumericPostalCode (prev.Value, PostalCodeString.Length, MaxPostalCodeInt);
+                var prev = GenerateSuccesorOrPredecessor (GetInternalValue (), false);
+                return (prev == null) ? null : new NumericPostalCode (prev.Value, PostalCodeString.Length, MaxPostalCodeInt);
             }
         }
 
@@ -25,22 +25,22 @@ namespace PostalCodes
         {
             get
             {
-				var next = GenerateSuccesorOrPredecessor (GetInternalValue (), true);
-				return (next == null) ? null : new NumericPostalCode (next.Value, PostalCodeString.Length, MaxPostalCodeInt);
+                var next = GenerateSuccesorOrPredecessor (GetInternalValue (), true);
+                return (next == null) ? null : new NumericPostalCode (next.Value, PostalCodeString.Length, MaxPostalCodeInt);
             }
         }
 
-		protected int GetInternalValue() {
-			return PostalCodeInt;
-		}
+        protected int GetInternalValue() {
+            return PostalCodeInt;
+        }
 
-		protected int? GenerateSuccesorOrPredecessor(int postalCode, bool getSuccesor) {
-			if (getSuccesor) {
-				return PostalCodeInt >= MaxPostalCodeInt ? null : PostalCodeInt + 1;
-			} else {
-				return PostalCodeInt <= 0 ? null : PostalCodeInt - 1;
-			}
-		}
+        protected int? GenerateSuccesorOrPredecessor(int postalCode, bool getSuccesor) {
+            if (getSuccesor) {
+                return PostalCodeInt >= MaxPostalCodeInt ? null : PostalCodeInt + 1;
+            } else {
+                return PostalCodeInt <= 0 ? null : PostalCodeInt - 1;
+            }
+        }
 
         public override int CompareTo(PostalCode other)
         {

--- a/src/PostalCodes/IsoCountryCodeConverter.cs
+++ b/src/PostalCodes/IsoCountryCodeConverter.cs
@@ -9,30 +9,30 @@ namespace PostalCodes
     public class IsoCountryCodeConverter
     {
         /// <summary>
-		/// Gets the iso3166-3 country code (if any).
+        /// Gets the iso3166-3 country code (if any).
         /// </summary>
         /// <returns>The iso3166p3 code.</returns>
         /// <param name="countryCode">Country code.</param>
         public string GetIso3166p3Code(string countryCode)
         {
-			var oldCode = Iso3166Countries.Countries.FirstOrDefault (a => a.NewCountryCodes.Contains (countryCode.ToUpperInvariant ()));
-			if (oldCode == default(Iso3166Country)) 
-			{
-				oldCode = Iso3166Countries.Countries.FirstOrDefault (a => a.Alpha2Code == countryCode);
-				if (oldCode == default(Iso3166Country)) 
-				{
-					throw new InvalidOperationException (string.Format ("The specified country code is not valid: {0}", countryCode));
-				}
-			}
+            var oldCode = Iso3166Countries.Countries.FirstOrDefault (a => a.NewCountryCodes.Contains (countryCode.ToUpperInvariant ()));
+            if (oldCode == default(Iso3166Country)) 
+            {
+                oldCode = Iso3166Countries.Countries.FirstOrDefault (a => a.Alpha2Code == countryCode);
+                if (oldCode == default(Iso3166Country)) 
+                {
+                    throw new InvalidOperationException (string.Format ("The specified country code is not valid: {0}", countryCode));
+                }
+            }
 
-			if (oldCode.Status == Iso3166CountryCodeStatus.NotUsed 
-				|| oldCode.Status == Iso3166CountryCodeStatus.Unassigned
-				|| oldCode.Status == Iso3166CountryCodeStatus.UserAssigned) 
-			{
-				throw new InvalidOperationException (string.Format ("The specified country code is not valid: {0}", countryCode));
-			}
+            if (oldCode.Status == Iso3166CountryCodeStatus.NotUsed 
+                || oldCode.Status == Iso3166CountryCodeStatus.Unassigned
+                || oldCode.Status == Iso3166CountryCodeStatus.UserAssigned) 
+            {
+                throw new InvalidOperationException (string.Format ("The specified country code is not valid: {0}", countryCode));
+            }
 
-			return oldCode.Alpha2Code;
+            return oldCode.Alpha2Code;
         }
     }
 }

--- a/src/PostalCodes/IsoCountryCodeValidator.cs
+++ b/src/PostalCodes/IsoCountryCodeValidator.cs
@@ -20,22 +20,22 @@ namespace PostalCodes
 
             try
             {
-				normalizedCountryCode = NormalizeToIso3166p1Alpha2(countryCode);
+                normalizedCountryCode = NormalizeToIso3166p1Alpha2(countryCode);
             }
             catch (InvalidOperationException)
             {
                 return false;
             }
 
-			var country = Iso3166Countries.Countries.FirstOrDefault(a => a.Alpha2Code == normalizedCountryCode);
-			if (country == default(Iso3166Country)) {
-				return false;
-			}
+            var country = Iso3166Countries.Countries.FirstOrDefault(a => a.Alpha2Code == normalizedCountryCode);
+            if (country == default(Iso3166Country)) {
+                return false;
+            }
 
-			return country.Status != Iso3166CountryCodeStatus.NotUsed
-			&& country.Status != Iso3166CountryCodeStatus.Unassigned
-			&& country.Status != Iso3166CountryCodeStatus.UserAssigned;
-		}
+            return country.Status != Iso3166CountryCodeStatus.NotUsed
+            && country.Status != Iso3166CountryCodeStatus.Unassigned
+            && country.Status != Iso3166CountryCodeStatus.UserAssigned;
+        }
 
         /// <summary>
         /// Gets the normalized country code based on ISO 3166-1 alpha-2 standards
@@ -44,9 +44,9 @@ namespace PostalCodes
         /// <returns>Normalized country code</returns>
         public string GetNormalizedCountryCode(string countryCode)
         {
-			var normalizedCountryCode = NormalizeToIso3166p1Alpha2(countryCode);
+            var normalizedCountryCode = NormalizeToIso3166p1Alpha2(countryCode);
             
-			if (!Iso3166Countries.Countries.Any(a => a.Alpha2Code == normalizedCountryCode))
+            if (!Iso3166Countries.Countries.Any(a => a.Alpha2Code == normalizedCountryCode))
             {
                 throw new InvalidOperationException(string.Format("The specified country code is not valid: {0}", countryCode));
             }
@@ -69,15 +69,15 @@ namespace PostalCodes
             }
 
             countryCode = countryCode.ToUpperInvariant();
-			var isoCountry = Iso3166Countries.Countries.FirstOrDefault (a => a.Alpha2Code == countryCode);
-			if (isoCountry != default(Iso3166Country)) {
-				if (isoCountry.NewCountryCodes.Length > 0) {
-					return isoCountry.NewCountryCodes[0];
-				}
-				return isoCountry.Alpha2Code;
-			}
+            var isoCountry = Iso3166Countries.Countries.FirstOrDefault (a => a.Alpha2Code == countryCode);
+            if (isoCountry != default(Iso3166Country)) {
+                if (isoCountry.NewCountryCodes.Length > 0) {
+                    return isoCountry.NewCountryCodes[0];
+                }
+                return isoCountry.Alpha2Code;
+            }
 
-			throw new InvalidOperationException("Unknown");
+            throw new InvalidOperationException("Unknown");
         }
     }
 }

--- a/src/PostalCodes/PostalCode.cs
+++ b/src/PostalCodes/PostalCode.cs
@@ -6,29 +6,29 @@ namespace PostalCodes
     /// <summary>
     /// Class PostalCode.
     /// </summary>
-	public abstract class PostalCode : IComparable<PostalCode>, IEquatable<PostalCode>, IComparable
+    public abstract class PostalCode : IComparable<PostalCode>, IEquatable<PostalCode>, IComparable
     {
-		/// <summary>
-		/// Format type.
-		/// </summary>
-		protected enum FormatType {
-			/// <summary>
-			/// The default.
-			/// </summary>
-			Default,
+        /// <summary>
+        /// Format type.
+        /// </summary>
+        protected enum FormatType {
+            /// <summary>
+            /// The default.
+            /// </summary>
+            Default,
 
-			/// <summary>
-			/// The short.
-			/// </summary>
-			Short
-		}
-			
+            /// <summary>
+            /// The short.
+            /// </summary>
+            Short
+        }
+
         /// <summary>
         /// The _backing postal code
         /// </summary>
         private readonly string _backingPostalCode;
         
-		/// <summary>
+        /// <summary>
         /// Gets the postal code string.
         /// </summary>
         /// <value>The postal code string.</value>
@@ -37,59 +37,59 @@ namespace PostalCodes
             get { return _backingPostalCode; }
         }
 
-		/// <summary>
-		/// The current format.
-		/// </summary>
-		protected PostalCodeFormat _currentFormat = null;
+        /// <summary>
+        /// The current format.
+        /// </summary>
+        protected PostalCodeFormat _currentFormat = null;
 
-		/// <summary>
-		/// The type of the current format.
-		/// </summary>
-		protected FormatType _currentFormatType = FormatType.Default;
+        /// <summary>
+        /// The type of the current format.
+        /// </summary>
+        protected FormatType _currentFormatType = FormatType.Default;
 
-		/// <summary>
-		/// The white space characters.
-		/// </summary>
-		protected string _whiteSpaceCharacters = " -";
+        /// <summary>
+        /// The white space characters.
+        /// </summary>
+        protected string _whiteSpaceCharacters = " -";
 
-		/// <summary>
-		/// The name of the country.
-		/// </summary>
-		protected string _countryName = "Default";
+        /// <summary>
+        /// The name of the country.
+        /// </summary>
+        protected string _countryName = "Default";
 
-		/// <summary>
-		/// The allow convert to short.
-		/// </summary>
-		protected bool _allowConvertToShort = true;
+        /// <summary>
+        /// The allow convert to short.
+        /// </summary>
+        protected bool _allowConvertToShort = true;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="PostalCodes.PostalCode"/> class.
-		/// </summary>
-		/// <param name="formats">Formats.</param>
-		/// <param name="postalCode">Postal code.</param>
-		internal PostalCode(PostalCodeFormat[] formats, string postalCode)
-			: this(formats, postalCode, true) {
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PostalCodes.PostalCode"/> class.
+        /// </summary>
+        /// <param name="formats">Formats.</param>
+        /// <param name="postalCode">Postal code.</param>
+        internal PostalCode(PostalCodeFormat[] formats, string postalCode)
+            : this(formats, postalCode, true) {
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="PostalCodes.PostalCode"/> class.
-		/// </summary>
-		/// <param name="formats">Formats.</param>
-		/// <param name="postalCode">Postal code.</param>
-		/// <param name="allowConvertToShort">If set to <c>true</c> allow convert to short format.</param>
-		internal PostalCode(PostalCodeFormat[] formats, string postalCode, bool allowConvertToShort)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PostalCodes.PostalCode"/> class.
+        /// </summary>
+        /// <param name="formats">Formats.</param>
+        /// <param name="postalCode">Postal code.</param>
+        /// <param name="allowConvertToShort">If set to <c>true</c> allow convert to short format.</param>
+        internal PostalCode(PostalCodeFormat[] formats, string postalCode, bool allowConvertToShort)
         {
-			_allowConvertToShort = allowConvertToShort;
+            _allowConvertToShort = allowConvertToShort;
 
-			var nonWhiteSpaceCode = ClearWhiteSpaces (postalCode);
+            var nonWhiteSpaceCode = ClearWhiteSpaces (postalCode);
 
-			string paddedPostalCode;
-			SetMatchingFormat(formats, nonWhiteSpaceCode, out paddedPostalCode);
-			if (paddedPostalCode != null) {
-				nonWhiteSpaceCode = paddedPostalCode;
-			}
+            string paddedPostalCode;
+            SetMatchingFormat(formats, nonWhiteSpaceCode, out paddedPostalCode);
+            if (paddedPostalCode != null) {
+                nonWhiteSpaceCode = paddedPostalCode;
+            }
 
-			_backingPostalCode = Normalize(nonWhiteSpaceCode);
+            _backingPostalCode = Normalize(nonWhiteSpaceCode);
         }
 
         /// <summary>
@@ -124,13 +124,13 @@ namespace PostalCodes
         /// Gets the predecessor implementation.
         /// </summary>
         /// <value>The predecessor implementation.</value>
-		protected abstract PostalCode PredecessorImpl { get; }
+        protected abstract PostalCode PredecessorImpl { get; }
         
         /// <summary>
         /// Gets the successor implementation.
         /// </summary>
         /// <value>The successor implementation.</value>
-		protected abstract PostalCode SuccessorImpl { get; }
+        protected abstract PostalCode SuccessorImpl { get; }
 
         #region Implementation of IComparable<in PostalCode>
 
@@ -296,26 +296,26 @@ namespace PostalCodes
             return PostalCodeString;
         }
 
-		/// <summary>
-		/// To the human readable string.
-		/// </summary>
-		/// <returns>The human readable string.</returns>
-		public virtual string ToHumanReadableString() 
-		{
-			return ToString ();
-		}
+        /// <summary>
+        /// To the human readable string.
+        /// </summary>
+        /// <returns>The human readable string.</returns>
+        public virtual string ToHumanReadableString() 
+        {
+            return ToString ();
+        }
 
-		/// <summary>
-		/// Expands the postal code as lowest in range.
-		/// </summary>
-		/// <returns>The postal code as lowest in range.</returns>
-		public abstract PostalCode ExpandPostalCodeAsLowestInRange();
+        /// <summary>
+        /// Expands the postal code as lowest in range.
+        /// </summary>
+        /// <returns>The postal code as lowest in range.</returns>
+        public abstract PostalCode ExpandPostalCodeAsLowestInRange();
 
-		/// <summary>
-		/// Expands the postal code as highest in range.
-		/// </summary>
-		/// <returns>The postal code as highest in range.</returns>
-		public abstract PostalCode ExpandPostalCodeAsHighestInRange();
+        /// <summary>
+        /// Expands the postal code as highest in range.
+        /// </summary>
+        /// <returns>The postal code as highest in range.</returns>
+        public abstract PostalCode ExpandPostalCodeAsHighestInRange();
 
         /// <summary>
         /// Ares the adjacent.
@@ -332,118 +332,118 @@ namespace PostalCodes
             return left.IsAdjacentTo(right) && right.IsAdjacentTo(left);
         }
 
-		/// <summary>
-		/// To the human readable string.
-		/// Each 'x' will be replaced by postal code char, the rest will be preserved.
-		/// Example: Code: A123, Format x x-xx => Result: A 1-23
-		/// </summary>
-		/// <returns>The human readable string.</returns>
-		/// <param name="outputFormat">Output format. </param>
-		protected virtual string ToHumanReadableString(string outputFormat) {
-			var result = "";
+        /// <summary>
+        /// To the human readable string.
+        /// Each 'x' will be replaced by postal code char, the rest will be preserved.
+        /// Example: Code: A123, Format x x-xx => Result: A 1-23
+        /// </summary>
+        /// <returns>The human readable string.</returns>
+        /// <param name="outputFormat">Output format. </param>
+        protected virtual string ToHumanReadableString(string outputFormat) {
+            var result = "";
 
-			var normalized = PostalCodeString;
-			var normalizedIndex = 0;
-			for (var i = 0; i < outputFormat.Length && normalizedIndex < PostalCodeString.Length; i++) 
-			{
-				result += outputFormat [i] == 'x' ? normalized [normalizedIndex++] : outputFormat [i];
-			}
+            var normalized = PostalCodeString;
+            var normalizedIndex = 0;
+            for (var i = 0; i < outputFormat.Length && normalizedIndex < PostalCodeString.Length; i++) 
+            {
+                result += outputFormat [i] == 'x' ? normalized [normalizedIndex++] : outputFormat [i];
+            }
 
-			return result;
-		}
+            return result;
+        }
 
-		private void SetMatchingFormat(PostalCodeFormat[] formats, string postalCode, out string outPaddedPostalCode) {
+        private void SetMatchingFormat(PostalCodeFormat[] formats, string postalCode, out string outPaddedPostalCode) {
 
-			outPaddedPostalCode = null;
+            outPaddedPostalCode = null;
 
-			foreach (var fmt in formats) {
-				if (fmt.RegexDefault.IsMatch (postalCode)) {
-					_currentFormatType = FormatType.Default;
-					_currentFormat = fmt;
-					return;
-				}
-				if (fmt.RegexShort != null) {
-					if (fmt.RegexShort.IsMatch (postalCode)) {
-						_currentFormatType = FormatType.Short;
-						_currentFormat = fmt;
-						return;
-					}
-				}
-			}
+            foreach (var fmt in formats) {
+                if (fmt.RegexDefault.IsMatch (postalCode)) {
+                    _currentFormatType = FormatType.Default;
+                    _currentFormat = fmt;
+                    return;
+                }
+                if (fmt.RegexShort != null) {
+                    if (fmt.RegexShort.IsMatch (postalCode)) {
+                        _currentFormatType = FormatType.Short;
+                        _currentFormat = fmt;
+                        return;
+                    }
+                }
+            }
 
-			// Let's give it a try by left padding...
-			foreach (var fmt in formats) {
-				if (fmt.LeftPaddingCharacter == null) {
-					continue;
-				}
+            // Let's give it a try by left padding...
+            foreach (var fmt in formats) {
+                if (fmt.LeftPaddingCharacter == null) {
+                    continue;
+                }
 
-				var expectedLength = fmt.OutputDefault.ToCharArray ().Count (a => a == 'x');
-				if (expectedLength < postalCode.Length) {
-					continue;
-				}
+                var expectedLength = fmt.OutputDefault.ToCharArray ().Count (a => a == 'x');
+                if (expectedLength < postalCode.Length) {
+                    continue;
+                }
 
-				var paddedPostalCode = postalCode.PadLeft (expectedLength, fmt.LeftPaddingCharacter[0]);
+                var paddedPostalCode = postalCode.PadLeft (expectedLength, fmt.LeftPaddingCharacter[0]);
 
-				if (fmt.RegexDefault.IsMatch (paddedPostalCode)) {
-					_currentFormatType = FormatType.Default;
-					_currentFormat = fmt;
-					outPaddedPostalCode = paddedPostalCode;
-					return;
-				}
-				if (fmt.RegexShort != null) {
-					if (fmt.RegexShort.IsMatch (paddedPostalCode)) {
-						_currentFormatType = FormatType.Short;
-						_currentFormat = fmt;
-						outPaddedPostalCode = paddedPostalCode;
-						return;
-					}
-				}
-			}
+                if (fmt.RegexDefault.IsMatch (paddedPostalCode)) {
+                    _currentFormatType = FormatType.Default;
+                    _currentFormat = fmt;
+                    outPaddedPostalCode = paddedPostalCode;
+                    return;
+                }
+                if (fmt.RegexShort != null) {
+                    if (fmt.RegexShort.IsMatch (paddedPostalCode)) {
+                        _currentFormatType = FormatType.Short;
+                        _currentFormat = fmt;
+                        outPaddedPostalCode = paddedPostalCode;
+                        return;
+                    }
+                }
+            }
 
-			throw new ArgumentException ("The input postal code doesn't match any format");
-		}
+            throw new ArgumentException ("The input postal code doesn't match any format");
+        }
 
-		/// <summary>
-		/// Clears the white spaces.
-		/// </summary>
-		/// <returns>The white spaces.</returns>
-		/// <param name="code">Code.</param>
-		protected virtual string ClearWhiteSpaces(string code) {
-			var normalized = code;
-			foreach (var c in _whiteSpaceCharacters.ToCharArray()) {
-				normalized = normalized.Replace (c + "", "");
-			}
-			return normalized;
-		}
+        /// <summary>
+        /// Clears the white spaces.
+        /// </summary>
+        /// <returns>The white spaces.</returns>
+        /// <param name="code">Code.</param>
+        protected virtual string ClearWhiteSpaces(string code) {
+            var normalized = code;
+            foreach (var c in _whiteSpaceCharacters.ToCharArray()) {
+                normalized = normalized.Replace (c + "", "");
+            }
+            return normalized;
+        }
 
-		/// <summary>
-		/// Normalize the specified code.
-		/// </summary>
-		/// <param name="code">Code.</param>
-		protected virtual string Normalize(string code)
-		{
-			var normalized = code;
-			if (_currentFormat.RegexDefault.IsMatch (normalized)) {
+        /// <summary>
+        /// Normalize the specified code.
+        /// </summary>
+        /// <param name="code">Code.</param>
+        protected virtual string Normalize(string code)
+        {
+            var normalized = code;
+            if (_currentFormat.RegexDefault.IsMatch (normalized)) {
 
-				if (_allowConvertToShort && _currentFormat.AutoConvertToShort) {
-						var charsInShortFormat = 0;
-					for (var j = 0; j < _currentFormat.OutputShort.Length; j++) {
-						if (_currentFormat.OutputShort [j] == 'x') {
-							charsInShortFormat++;
-						}
-					}
-					normalized = normalized.Substring (0, charsInShortFormat);
-				}
-				return normalized;
-			}
+                if (_allowConvertToShort && _currentFormat.AutoConvertToShort) {
+                        var charsInShortFormat = 0;
+                    for (var j = 0; j < _currentFormat.OutputShort.Length; j++) {
+                        if (_currentFormat.OutputShort [j] == 'x') {
+                            charsInShortFormat++;
+                        }
+                    }
+                    normalized = normalized.Substring (0, charsInShortFormat);
+                }
+                return normalized;
+            }
 
-			if (_currentFormat.RegexShort != null) {
-				if (_currentFormat.RegexShort.IsMatch (normalized)) {
-					return normalized;
-				}
-			}
-				
-			throw new ArgumentException (string.Format ("Failed to normalize postal code '{0}'", code));
-		}
+            if (_currentFormat.RegexShort != null) {
+                if (_currentFormat.RegexShort.IsMatch (normalized)) {
+                    return normalized;
+                }
+            }
+
+            throw new ArgumentException (string.Format ("Failed to normalize postal code '{0}'", code));
+        }
     }
 }

--- a/src/PostalCodes/PostalCodeRange.cs
+++ b/src/PostalCodes/PostalCodeRange.cs
@@ -13,7 +13,7 @@ namespace PostalCodes
         /// </summary>
         private static readonly Lazy<PostalCodeRange> LazyDefault = new Lazy<PostalCodeRange>(() => new PostalCodeRange(null, null));
         
-		/// <summary>
+        /// <summary>
         /// Gets the default.
         /// </summary>
         /// <value>The default.</value>
@@ -30,16 +30,16 @@ namespace PostalCodes
         /// <exception cref="System.ArgumentException"></exception>
         public PostalCodeRange(PostalCode start, PostalCode end)
         {
-			if (start != null && end != null && start.GetType() != end.GetType()) {
-				throw new ArgumentException(String.Format(
-					"The star and the end of the range are from incompatible types ('{0}' & '{1}')",
-					start.GetType(), end.GetType()));
-			}
+            if (start != null && end != null && start.GetType() != end.GetType()) {
+                throw new ArgumentException(String.Format(
+                    "The star and the end of the range are from incompatible types ('{0}' & '{1}')",
+                    start.GetType(), end.GetType()));
+            }
 
             if (end != null && start != null && start > end)
             {
                 throw new ArgumentException(String.Format(
-					"PostalCodeRange end ({0}) can't be before start ({1})", end, start));
+                    "PostalCodeRange end ({0}) can't be before start ({1})", end, start));
             }
 
             Start = start;


### PR DESCRIPTION
GitHub and my editor show tabs as 8 spaces wide. Some C# files use a mixture of 4 spaces and tabs for indentation which looks horrible, so I changed the tabs to spaces.

There are a few files using only tabs, which I left alone:
```
PostalCodes/Extensions/BBPostalCode.cs
PostalCodes/GenericPostalCodes/DefaultPostalCode.cs
PostalCodes/Iso3166Countries.cs
PostalCodes/Iso3166Country.cs
PostalCodes/Iso3166CountryCodeStatus.cs
PostalCodes/PostalCodeFormat.cs
```