### PR TITLE
Adding PL postal code. 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,13 @@ build:
   verbosity: normal
 test_script:
 - cmd:
-    ECHO ON
+    echo RepoToken=%COVERALLS_REPO_TOKEN%
+    echo Commit=%APPVEYOR_REPO_COMMIT%
+    echo Branch=%APPVEYOR_REPO_BRANCH%
+    echo Author=%APPVEYOR_REPO_COMMIT_AUTHOR%
+    echo AuthorEmail=%APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL%
+    echo CommitMessage=%APPVEYOR_REPO_COMMIT_MESSAGE%
+    echo JobId=%APPVEYOR_JOB_ID%
 
     .\packages\OpenCover.4.5.3723\OpenCover.Console.exe -register:user -target:"packages\NUnit.Runners.2.6.4\tools\nunit-console.exe" -register:user "-targetargs:""src\PostalCodes.UnitTests\bin\Release\PostalCodes.UnitTests.dll"" /noshadow" -filter:"+[PostalCodes*]*" -output:opencoverCoverage.xml
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,18 +16,9 @@ build:
   verbosity: normal
 test_script:
 - cmd:
-    echo RepoToken=%COVERALLS_REPO_TOKEN%
-    echo Commit=%APPVEYOR_REPO_COMMIT%
-    echo Branch=%APPVEYOR_REPO_BRANCH%
-    echo Author=%APPVEYOR_REPO_COMMIT_AUTHOR%
-    echo AuthorEmail=%APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL%
-    echo CommitMessage=%APPVEYOR_REPO_COMMIT_MESSAGE%
-    echo JobId=%APPVEYOR_JOB_ID%
-
     .\packages\OpenCover.4.5.3723\OpenCover.Console.exe -register:user -target:"packages\NUnit.Runners.2.6.4\tools\nunit-console.exe" -register:user "-targetargs:""src\PostalCodes.UnitTests\bin\Release\PostalCodes.UnitTests.dll"" /noshadow" -filter:"+[PostalCodes*]*" -output:opencoverCoverage.xml
-
+    IF [%COVERALLS_REPO_TOKEN%] == [] exit 0
     .\packages\coveralls.net.0.5.0\csmacnz.Coveralls.exe --opencover -i opencoverCoverage.xml --repoToken "%COVERALLS_REPO_TOKEN%" --commitId "%APPVEYOR_REPO_COMMIT%" --commitBranch "%APPVEYOR_REPO_BRANCH%" --commitAuthor "%APPVEYOR_REPO_COMMIT_AUTHOR%" --commitEmail "%APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL%" --commitMessage "%APPVEYOR_REPO_COMMIT_MESSAGE%" --jobId "%APPVEYOR_JOB_ID%"
-
 artifacts:
 - path: src\PostalCodes\bin\*\*.nupkg
   name: NuGet

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,8 +17,11 @@ build:
 test_script:
 - cmd:
     .\packages\OpenCover.4.5.3723\OpenCover.Console.exe -register:user -target:"packages\NUnit.Runners.2.6.4\tools\nunit-console.exe" -register:user "-targetargs:""src\PostalCodes.UnitTests\bin\Release\PostalCodes.UnitTests.dll"" /noshadow" -filter:"+[PostalCodes*]*" -output:opencoverCoverage.xml
+
     IF [%COVERALLS_REPO_TOKEN%] == [] exit 0
+
     .\packages\coveralls.net.0.5.0\csmacnz.Coveralls.exe --opencover -i opencoverCoverage.xml --repoToken "%COVERALLS_REPO_TOKEN%" --commitId "%APPVEYOR_REPO_COMMIT%" --commitBranch "%APPVEYOR_REPO_BRANCH%" --commitAuthor "%APPVEYOR_REPO_COMMIT_AUTHOR%" --commitEmail "%APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL%" --commitMessage "%APPVEYOR_REPO_COMMIT_MESSAGE%" --jobId "%APPVEYOR_JOB_ID%"
+
 artifacts:
 - path: src\PostalCodes\bin\*\*.nupkg
   name: NuGet

--- a/scripts/PL.json
+++ b/scripts/PL.json
@@ -1,0 +1,36 @@
+{
+	"CountryName" : "Poland",
+	"CountryCodeAlpha2" : "PL",
+	"WhiteSpaceCharacters" : " -",
+	"Formats" : [
+			{
+				"Name" : "PL : 99-999",
+				"RegexDefault" : "^[0-9]{2}-[0-9]{3}$",
+				"OutputDefault" : "xx-xxx"
+			},
+			{
+				"Name" : "PL : 99999",
+				"RegexDefault" : "^[0-9]{5}$",
+				"OutputDefault" : "xxxxx"
+			}		
+		],
+
+	"TestData" : {
+		"Max" : [ "99999", "99-999" ],
+		"Min" : [ "00000", "00-000" ],
+		"Valid" : ["44100", "44-100"],
+		"Invalid" : [ "44f00", "e4410", "44-100d", "c44-100", "b44100", "44100a" ],
+		"Predecessor" : {
+			"44-100" : "44-099",
+			"00-001" : "00-000",
+			"44100" : "44-099",
+			"00-001" : "00000"
+		},
+		"Successor" : {
+			"44-100" : "44-101",
+			"00-001" : "00-002",
+			"44100" : "44-101",
+			"00-001" : "00002"
+		}
+	}
+}

--- a/scripts/generate.postalcodes.py
+++ b/scripts/generate.postalcodes.py
@@ -167,5 +167,5 @@ for countryCode, className in allGeneratedPostalCodeClasses.iteritems():
 generatePostalCodeFactory(cases)
 
 print ""
-print "!!! Please make sure the generated files are added to the csproj file."
+print "All generated *.gen.cs files are added in the csproj file with wildcard."
 print ""

--- a/scripts/generate.postalcodes.py
+++ b/scripts/generate.postalcodes.py
@@ -56,37 +56,38 @@ def generateUnitTestFile(countryCode, testData):
     if "Predecessor" in testData:
         testCases = ""
         for code,prevCode in testData["Predecessor"].iteritems():
-            testCases = off(2) + "[TestCase(\"" + code + "\",\"" + prevCode + "\")]" + endl()
+            testCases += off(2) + "[TestCase(\"" + code + "\",\"" + prevCode + "\")]" + endl()
         template = template.replace("@@testsPredecessor@@", testCases[:-2])
 
     if "Successor" in testData:
         testCases = ""
         for code,nextCode in testData["Successor"].iteritems():
-            testCases = off(2) + "[TestCase(\"" + code + "\",\"" + nextCode + "\")]" + endl()
+            testCases += off(2) + "[TestCase(\"" + code + "\",\"" + nextCode + "\")]" + endl()
+            
         template = template.replace("@@testsSuccessor@@", testCases[:-2])
 
     if "Min" in testData:
         testCases = ""
         for code in testData["Min"]:
-            testCases = off(2) + "[TestCase(\"" + code + "\")]" + endl()
+            testCases += off(2) + "[TestCase(\"" + code + "\")]" + endl()
         template = template.replace("@@testsMin@@", testCases[:-2])
 
     if "Max" in testData:
         testCases = ""
         for code in testData["Max"]:
-            testCases = off(2) + "[TestCase(\"" + code + "\")]" + endl()
+            testCases += off(2) + "[TestCase(\"" + code + "\")]" + endl()
         template = template.replace("@@testsMax@@", testCases[:-2])
 
     if "Valid" in testData:
         testCases = ""
         for code in testData["Valid"]:
-            testCases = off(2) + "[TestCase(\"" + code + "\")]" + endl()
+            testCases += off(2) + "[TestCase(\"" + code + "\")]" + endl()
         template = template.replace("@@testsValid@@", testCases[:-2])
 
     if "Invalid" in testData:
         testCases = ""
         for code in testData["Invalid"]:
-            testCases = off(2) + "[TestCase(\"" + code + "\")]" + endl()
+            testCases += off(2) + "[TestCase(\"" + code + "\")]" + endl()
         template = template.replace("@@testsInvalid@@", testCases[:-2])
 
     path = scriptPath + "../src/PostalCodes.UnitTests/Generated/" + countryCode + "PostalCodeTests.gen.cs"

--- a/scripts/postalcodeunittests.cs.template
+++ b/scripts/postalcodeunittests.cs.template
@@ -11,16 +11,23 @@ namespace PostalCodes.UnitTests.Generated
         public void Predecessor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodePredecessor)
         {
             var code = new @@CountryCode@@PostalCode(postalCode);
-            Assert.AreEqual(postalCodePredecessor, code.Predecessor.ToString());
+            var codePredecessor = new @@CountryCode@@PostalCode(postalCodePredecessor);
+            Assert.AreEqual(codePredecessor, code.Predecessor);
+            Assert.AreEqual(codePredecessor.ToString(), code.Predecessor.ToString());
+            Assert.AreEqual(codePredecessor.ToHumanReadableString(), code.Predecessor.ToHumanReadableString());
         }
 
 @@testsSuccessor@@
         public void Successor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodeSuccessor)
         {
             var code = new @@CountryCode@@PostalCode(postalCode);
-            Assert.AreEqual(postalCodeSuccessor, code.Successor.ToString());
-        }
+            var codeSuccessor = new @@CountryCode@@PostalCode(postalCodeSuccessor);
+            Assert.AreEqual(codeSuccessor, code.Successor);
+            Assert.AreEqual(codeSuccessor.ToString(), code.Successor.ToString());
+            Assert.AreEqual(codeSuccessor.ToHumanReadableString(), code.Successor.ToHumanReadableString());
 
+        }
+        
 @@testsMin@@
         public void Predecessor_FirstInRange_ReturnsNull(string postalCode)
         {

--- a/src/PostalCodes.UnitTests/Generated/BBPostalCodeTests.gen.cs
+++ b/src/PostalCodes.UnitTests/Generated/BBPostalCodeTests.gen.cs
@@ -7,6 +7,7 @@ namespace PostalCodes.UnitTests.Generated
     internal class BBPostalCodeTests
     {
 
+        [TestCase("12345","12344")]
         [TestCase("BB 12345","12344")]
         public void Predecessor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodePredecessor)
         {
@@ -17,6 +18,7 @@ namespace PostalCodes.UnitTests.Generated
             Assert.AreEqual(codePredecessor.ToHumanReadableString(), code.Predecessor.ToHumanReadableString());
         }
 
+        [TestCase("12345","12346")]
         [TestCase("BB 12345","12346")]
         public void Successor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodeSuccessor)
         {
@@ -28,24 +30,28 @@ namespace PostalCodes.UnitTests.Generated
 
         }
         
+        [TestCase("BB00000")]
         [TestCase("00000")]
         public void Predecessor_FirstInRange_ReturnsNull(string postalCode)
         {
             Assert.IsNull((new BBPostalCode(postalCode)).Predecessor);
         }
 
+        [TestCase("BB99999")]
         [TestCase("99999")]
         public void Successor_LastInRange_ReturnsNull(string postalCode)
         {
             Assert.IsNull((new BBPostalCode(postalCode)).Successor);
         }
 
+        [TestCase("x1231s")]
         [TestCase("1231sd")]
         public void InvalidCode_ThrowsArgumentException(string postalCode)
         {
             Assert.Throws<ArgumentException>(() => new BBPostalCode(postalCode));
         }
 
+        [TestCase("BB12345")]
         [TestCase("12345")]
         public void Predecessor_ValidInput_ReturnsCorrectPostalCodeObject(string code)
         {
@@ -53,6 +59,7 @@ namespace PostalCodes.UnitTests.Generated
             Assert.IsTrue(x.GetType() == typeof(BBPostalCode));
         }
 
+        [TestCase("BB12345")]
         [TestCase("12345")]
         public void Successor_ValidInput_ReturnsCorrectPostalCodeObject(string code)
         {

--- a/src/PostalCodes.UnitTests/Generated/PLPostalCodeTests.gen.cs
+++ b/src/PostalCodes.UnitTests/Generated/PLPostalCodeTests.gen.cs
@@ -7,6 +7,8 @@ namespace PostalCodes.UnitTests.Generated
     internal class PLPostalCodeTests
     {
 
+        [TestCase("44-100","44-099")]
+        [TestCase("00-001","00000")]
         [TestCase("44100","44-099")]
         public void Predecessor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodePredecessor)
         {
@@ -17,6 +19,8 @@ namespace PostalCodes.UnitTests.Generated
             Assert.AreEqual(codePredecessor.ToHumanReadableString(), code.Predecessor.ToHumanReadableString());
         }
 
+        [TestCase("44-100","44-101")]
+        [TestCase("00-001","00002")]
         [TestCase("44100","44-101")]
         public void Successor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodeSuccessor)
         {
@@ -28,24 +32,32 @@ namespace PostalCodes.UnitTests.Generated
 
         }
         
+        [TestCase("00000")]
         [TestCase("00-000")]
         public void Predecessor_FirstInRange_ReturnsNull(string postalCode)
         {
             Assert.IsNull((new PLPostalCode(postalCode)).Predecessor);
         }
 
+        [TestCase("99999")]
         [TestCase("99-999")]
         public void Successor_LastInRange_ReturnsNull(string postalCode)
         {
             Assert.IsNull((new PLPostalCode(postalCode)).Successor);
         }
 
+        [TestCase("44f00")]
+        [TestCase("e4410")]
+        [TestCase("44-100d")]
+        [TestCase("c44-100")]
+        [TestCase("b44100")]
         [TestCase("44100a")]
         public void InvalidCode_ThrowsArgumentException(string postalCode)
         {
             Assert.Throws<ArgumentException>(() => new PLPostalCode(postalCode));
         }
 
+        [TestCase("44100")]
         [TestCase("44-100")]
         public void Predecessor_ValidInput_ReturnsCorrectPostalCodeObject(string code)
         {
@@ -53,6 +65,7 @@ namespace PostalCodes.UnitTests.Generated
             Assert.IsTrue(x.GetType() == typeof(PLPostalCode));
         }
 
+        [TestCase("44100")]
         [TestCase("44-100")]
         public void Successor_ValidInput_ReturnsCorrectPostalCodeObject(string code)
         {

--- a/src/PostalCodes.UnitTests/Generated/PLPostalCodeTests.gen.cs
+++ b/src/PostalCodes.UnitTests/Generated/PLPostalCodeTests.gen.cs
@@ -4,60 +4,60 @@ using NUnit.Framework;
 namespace PostalCodes.UnitTests.Generated
 {
     [TestFixture]
-    internal class BBPostalCodeTests
+    internal class PLPostalCodeTests
     {
 
-        [TestCase("BB 12345","12344")]
+        [TestCase("44100","44-099")]
         public void Predecessor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodePredecessor)
         {
-            var code = new BBPostalCode(postalCode);
-            var codePredecessor = new BBPostalCode(postalCodePredecessor);
+            var code = new PLPostalCode(postalCode);
+            var codePredecessor = new PLPostalCode(postalCodePredecessor);
             Assert.AreEqual(codePredecessor, code.Predecessor);
             Assert.AreEqual(codePredecessor.ToString(), code.Predecessor.ToString());
             Assert.AreEqual(codePredecessor.ToHumanReadableString(), code.Predecessor.ToHumanReadableString());
         }
 
-        [TestCase("BB 12345","12346")]
+        [TestCase("44100","44-101")]
         public void Successor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodeSuccessor)
         {
-            var code = new BBPostalCode(postalCode);
-            var codeSuccessor = new BBPostalCode(postalCodeSuccessor);
+            var code = new PLPostalCode(postalCode);
+            var codeSuccessor = new PLPostalCode(postalCodeSuccessor);
             Assert.AreEqual(codeSuccessor, code.Successor);
             Assert.AreEqual(codeSuccessor.ToString(), code.Successor.ToString());
             Assert.AreEqual(codeSuccessor.ToHumanReadableString(), code.Successor.ToHumanReadableString());
 
         }
         
-        [TestCase("00000")]
+        [TestCase("00-000")]
         public void Predecessor_FirstInRange_ReturnsNull(string postalCode)
         {
-            Assert.IsNull((new BBPostalCode(postalCode)).Predecessor);
+            Assert.IsNull((new PLPostalCode(postalCode)).Predecessor);
         }
 
-        [TestCase("99999")]
+        [TestCase("99-999")]
         public void Successor_LastInRange_ReturnsNull(string postalCode)
         {
-            Assert.IsNull((new BBPostalCode(postalCode)).Successor);
+            Assert.IsNull((new PLPostalCode(postalCode)).Successor);
         }
 
-        [TestCase("1231sd")]
+        [TestCase("44100a")]
         public void InvalidCode_ThrowsArgumentException(string postalCode)
         {
-            Assert.Throws<ArgumentException>(() => new BBPostalCode(postalCode));
+            Assert.Throws<ArgumentException>(() => new PLPostalCode(postalCode));
         }
 
-        [TestCase("12345")]
+        [TestCase("44-100")]
         public void Predecessor_ValidInput_ReturnsCorrectPostalCodeObject(string code)
         {
-            var x = (new BBPostalCode(code)).Predecessor;
-            Assert.IsTrue(x.GetType() == typeof(BBPostalCode));
+            var x = (new PLPostalCode(code)).Predecessor;
+            Assert.IsTrue(x.GetType() == typeof(PLPostalCode));
         }
 
-        [TestCase("12345")]
+        [TestCase("44-100")]
         public void Successor_ValidInput_ReturnsCorrectPostalCodeObject(string code)
         {
-            var x = (new BBPostalCode(code)).Successor;
-            Assert.IsTrue(x.GetType() == typeof(BBPostalCode));
+            var x = (new PLPostalCode(code)).Successor;
+            Assert.IsTrue(x.GetType() == typeof(PLPostalCode));
         }
     }
 }

--- a/src/PostalCodes.UnitTests/Generated/RUPostalCodeTests.gen.cs
+++ b/src/PostalCodes.UnitTests/Generated/RUPostalCodeTests.gen.cs
@@ -11,16 +11,23 @@ namespace PostalCodes.UnitTests.Generated
         public void Predecessor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodePredecessor)
         {
             var code = new RUPostalCode(postalCode);
-            Assert.AreEqual(postalCodePredecessor, code.Predecessor.ToString());
+            var codePredecessor = new RUPostalCode(postalCodePredecessor);
+            Assert.AreEqual(codePredecessor, code.Predecessor);
+            Assert.AreEqual(codePredecessor.ToString(), code.Predecessor.ToString());
+            Assert.AreEqual(codePredecessor.ToHumanReadableString(), code.Predecessor.ToHumanReadableString());
         }
 
         [TestCase("123456","123457")]
         public void Successor_ValidInput_ReturnsCorrectPostalCode(string postalCode, string postalCodeSuccessor)
         {
             var code = new RUPostalCode(postalCode);
-            Assert.AreEqual(postalCodeSuccessor, code.Successor.ToString());
-        }
+            var codeSuccessor = new RUPostalCode(postalCodeSuccessor);
+            Assert.AreEqual(codeSuccessor, code.Successor);
+            Assert.AreEqual(codeSuccessor.ToString(), code.Successor.ToString());
+            Assert.AreEqual(codeSuccessor.ToHumanReadableString(), code.Successor.ToHumanReadableString());
 
+        }
+        
         [TestCase("000000")]
         public void Predecessor_FirstInRange_ReturnsNull(string postalCode)
         {

--- a/src/PostalCodes.UnitTests/Generated/RUPostalCodeTests.gen.cs
+++ b/src/PostalCodes.UnitTests/Generated/RUPostalCodeTests.gen.cs
@@ -29,17 +29,20 @@ namespace PostalCodes.UnitTests.Generated
         }
         
         [TestCase("000000")]
+        [TestCase("000000")]
         public void Predecessor_FirstInRange_ReturnsNull(string postalCode)
         {
             Assert.IsNull((new RUPostalCode(postalCode)).Predecessor);
         }
 
         [TestCase("999999")]
+        [TestCase("999999")]
         public void Successor_LastInRange_ReturnsNull(string postalCode)
         {
             Assert.IsNull((new RUPostalCode(postalCode)).Successor);
         }
 
+        [TestCase("x1231s")]
         [TestCase("1231sd")]
         public void InvalidCode_ThrowsArgumentException(string postalCode)
         {

--- a/src/PostalCodes/Generated/PLPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PLPostalCode.gen.cs
@@ -10,7 +10,7 @@ namespace PostalCodes
 
         public PLPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
         {
-            _countryName = "PL";
+            _countryName = "Poland";
         }
 
         private PLPostalCode(PostalCode other) : base(_formats, other.ToString()) {}
@@ -97,13 +97,14 @@ namespace PostalCodes
 
         private static PostalCodeFormat[] _formats = new [] {
             new PostalCodeFormat {
-                Name = "5-Digits - 99999",
+                Name = "PL : 99-999",
+                RegexDefault = new Regex("^[0-9]{2}-[0-9]{3}$", RegexOptions.Compiled),
+                OutputDefault = "xx-xxx",
+            },
+            new PostalCodeFormat {
+                Name = "PL : 99999",
                 RegexDefault = new Regex("^[0-9]{5}$", RegexOptions.Compiled),
                 OutputDefault = "xxxxx",
-                AutoConvertToShort = false,
-                ShortExpansionAsLowestInRange = "0",
-                ShortExpansionAsHighestInRange = "9",
-                LeftPaddingCharacter = "0",
             }
         };
     }


### PR DESCRIPTION
To experiment with the JSON configuration, I added ``PL.json``, and changed the scripts that generate the tests to comply more with was my expectation of the successor/predecessor test.