### PR TITLE
Handle all country codes consistently

### DIFF
--- a/src/PostalCodes.UnitTests/IsoCountryCodeConverterTests.cs
+++ b/src/PostalCodes.UnitTests/IsoCountryCodeConverterTests.cs
@@ -28,6 +28,14 @@ namespace PostalCodes.UnitTests
         }
 
         [Test]
+        [TestCase("gb")]
+        [TestCase("us")]
+        public void GetIso3166p3Code_WithLowerCaseIso31661p1Code_ThrowsInvalidOperationException(string input)
+        {
+            Assert.Throws<InvalidOperationException>(() => IsoConverter.GetIso3166p3Code(input));
+        }
+
+        [Test]
         [TestCase("IH")]
         [TestCase("KJ")]
         [TestCase("IY")]

--- a/src/PostalCodes/IsoCountryCodeConverter.cs
+++ b/src/PostalCodes/IsoCountryCodeConverter.cs
@@ -11,11 +11,11 @@ namespace PostalCodes
         /// <summary>
         /// Gets the iso3166-3 country code (if any).
         /// </summary>
-        /// <returns>The iso3166p3 code.</returns>
         /// <param name="countryCode">Country code.</param>
+        /// <returns>The iso3166p3 code.</returns>
         public string GetIso3166p3Code(string countryCode)
         {
-            var oldCode = Iso3166Countries.Countries.FirstOrDefault (a => a.NewCountryCodes.Contains (countryCode.ToUpperInvariant ()));
+            var oldCode = Iso3166Countries.Countries.FirstOrDefault (a => a.NewCountryCodes.Contains (countryCode));
             if (oldCode == default(Iso3166Country)) 
             {
                 oldCode = Iso3166Countries.Countries.FirstOrDefault (a => a.Alpha2Code == countryCode);


### PR DESCRIPTION
My first unit test, test-driven development ftw \o/

I think it's clearer to not call `ToUpperInvariant()` in either case. Otherwise we should add at least trimming too and move it to some `LightweightCountryCodeNormalizer` class. Half-way normalization is worse than none.