### PR TITLE
Take into account WhiteSpaceCharacters attribute 

### DIFF
--- a/src/PostalCodes/Generated/AFPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/AFPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class AFPostalCode : AlphaNumericPostalCode
     {
-        public AFPostalCode(string postalCode) : this(postalCode, true) {}
+        public AFPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public AFPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public AFPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "AF";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new AFPostalCode(code, allowConvertToShort);
+            return new AFPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ALPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ALPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ALPostalCode : AlphaNumericPostalCode
     {
-        public ALPostalCode(string postalCode) : this(postalCode, true) {}
+        public ALPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ALPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ALPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "AL";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ALPostalCode(code, allowConvertToShort);
+            return new ALPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/AMPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/AMPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class AMPostalCode : AlphaNumericPostalCode
     {
-        public AMPostalCode(string postalCode) : this(postalCode, true) {}
+        public AMPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public AMPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public AMPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "AM";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new AMPostalCode(code, allowConvertToShort);
+            return new AMPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ARPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ARPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ARPostalCode : AlphaNumericPostalCode
     {
-        public ARPostalCode(string postalCode) : this(postalCode, true) {}
+        public ARPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ARPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ARPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "AR";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ARPostalCode(code, allowConvertToShort);
+            return new ARPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ASPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ASPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ASPostalCode : AlphaNumericPostalCode
     {
-        public ASPostalCode(string postalCode) : this(postalCode, true) {}
+        public ASPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ASPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ASPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "AS";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ASPostalCode(code, allowConvertToShort);
+            return new ASPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ATPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ATPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ATPostalCode : AlphaNumericPostalCode
     {
-        public ATPostalCode(string postalCode) : this(postalCode, true) {}
+        public ATPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ATPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ATPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "AT";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ATPostalCode(code, allowConvertToShort);
+            return new ATPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/AUPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/AUPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class AUPostalCode : AlphaNumericPostalCode
     {
-        public AUPostalCode(string postalCode) : this(postalCode, true) {}
+        public AUPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public AUPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public AUPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "AU";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new AUPostalCode(code, allowConvertToShort);
+            return new AUPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/BAPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/BAPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class BAPostalCode : AlphaNumericPostalCode
     {
-        public BAPostalCode(string postalCode) : this(postalCode, true) {}
+        public BAPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public BAPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public BAPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "BA";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new BAPostalCode(code, allowConvertToShort);
+            return new BAPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/BBPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/BBPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class BBPostalCode : AlphaNumericPostalCode
     {
-        public BBPostalCode(string postalCode) : this(postalCode, true) {}
+        public BBPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public BBPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public BBPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "Barbados";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new BBPostalCode(code, allowConvertToShort);
+            return new BBPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/BDPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/BDPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class BDPostalCode : AlphaNumericPostalCode
     {
-        public BDPostalCode(string postalCode) : this(postalCode, true) {}
+        public BDPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public BDPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public BDPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "BD";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new BDPostalCode(code, allowConvertToShort);
+            return new BDPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/BEPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/BEPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class BEPostalCode : AlphaNumericPostalCode
     {
-        public BEPostalCode(string postalCode) : this(postalCode, true) {}
+        public BEPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public BEPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public BEPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "BE";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new BEPostalCode(code, allowConvertToShort);
+            return new BEPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/BGPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/BGPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class BGPostalCode : AlphaNumericPostalCode
     {
-        public BGPostalCode(string postalCode) : this(postalCode, true) {}
+        public BGPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public BGPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public BGPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "BG";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new BGPostalCode(code, allowConvertToShort);
+            return new BGPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/BOPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/BOPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class BOPostalCode : AlphaNumericPostalCode
     {
-        public BOPostalCode(string postalCode) : this(postalCode, true) {}
+        public BOPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public BOPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public BOPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "BO";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new BOPostalCode(code, allowConvertToShort);
+            return new BOPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/BTPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/BTPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class BTPostalCode : AlphaNumericPostalCode
     {
-        public BTPostalCode(string postalCode) : this(postalCode, true) {}
+        public BTPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public BTPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public BTPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "BT";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new BTPostalCode(code, allowConvertToShort);
+            return new BTPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/BYPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/BYPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class BYPostalCode : AlphaNumericPostalCode
     {
-        public BYPostalCode(string postalCode) : this(postalCode, true) {}
+        public BYPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public BYPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public BYPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "BY";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new BYPostalCode(code, allowConvertToShort);
+            return new BYPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/CAPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/CAPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class CAPostalCode : AlphaNumericPostalCode
     {
-        public CAPostalCode(string postalCode) : this(postalCode, true) {}
+        public CAPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public CAPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public CAPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "Canada";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new CAPostalCode(code, allowConvertToShort);
+            return new CAPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/CCPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/CCPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class CCPostalCode : AlphaNumericPostalCode
     {
-        public CCPostalCode(string postalCode) : this(postalCode, true) {}
+        public CCPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public CCPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public CCPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "CC";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new CCPostalCode(code, allowConvertToShort);
+            return new CCPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/CHPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/CHPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class CHPostalCode : AlphaNumericPostalCode
     {
-        public CHPostalCode(string postalCode) : this(postalCode, true) {}
+        public CHPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public CHPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public CHPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "CH";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new CHPostalCode(code, allowConvertToShort);
+            return new CHPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/CNPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/CNPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class CNPostalCode : AlphaNumericPostalCode
     {
-        public CNPostalCode(string postalCode) : this(postalCode, true) {}
+        public CNPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public CNPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public CNPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "CN";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new CNPostalCode(code, allowConvertToShort);
+            return new CNPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/COPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/COPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class COPostalCode : AlphaNumericPostalCode
     {
-        public COPostalCode(string postalCode) : this(postalCode, true) {}
+        public COPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public COPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public COPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "CO";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new COPostalCode(code, allowConvertToShort);
+            return new COPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/CRPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/CRPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class CRPostalCode : AlphaNumericPostalCode
     {
-        public CRPostalCode(string postalCode) : this(postalCode, true) {}
+        public CRPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public CRPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public CRPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "CR";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new CRPostalCode(code, allowConvertToShort);
+            return new CRPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/CUPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/CUPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class CUPostalCode : AlphaNumericPostalCode
     {
-        public CUPostalCode(string postalCode) : this(postalCode, true) {}
+        public CUPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public CUPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public CUPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "CU";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new CUPostalCode(code, allowConvertToShort);
+            return new CUPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/CVPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/CVPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class CVPostalCode : AlphaNumericPostalCode
     {
-        public CVPostalCode(string postalCode) : this(postalCode, true) {}
+        public CVPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public CVPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public CVPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "CV";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new CVPostalCode(code, allowConvertToShort);
+            return new CVPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/CXPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/CXPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class CXPostalCode : AlphaNumericPostalCode
     {
-        public CXPostalCode(string postalCode) : this(postalCode, true) {}
+        public CXPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public CXPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public CXPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "CX";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new CXPostalCode(code, allowConvertToShort);
+            return new CXPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/CYPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/CYPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class CYPostalCode : AlphaNumericPostalCode
     {
-        public CYPostalCode(string postalCode) : this(postalCode, true) {}
+        public CYPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public CYPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public CYPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "CY";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new CYPostalCode(code, allowConvertToShort);
+            return new CYPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/CZPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/CZPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class CZPostalCode : AlphaNumericPostalCode
     {
-        public CZPostalCode(string postalCode) : this(postalCode, true) {}
+        public CZPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public CZPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public CZPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "CZ";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new CZPostalCode(code, allowConvertToShort);
+            return new CZPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/DEPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/DEPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class DEPostalCode : AlphaNumericPostalCode
     {
-        public DEPostalCode(string postalCode) : this(postalCode, true) {}
+        public DEPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public DEPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public DEPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "DE";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new DEPostalCode(code, allowConvertToShort);
+            return new DEPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/DKPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/DKPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class DKPostalCode : AlphaNumericPostalCode
     {
-        public DKPostalCode(string postalCode) : this(postalCode, true) {}
+        public DKPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public DKPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public DKPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "DK";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new DKPostalCode(code, allowConvertToShort);
+            return new DKPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/DOPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/DOPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class DOPostalCode : AlphaNumericPostalCode
     {
-        public DOPostalCode(string postalCode) : this(postalCode, true) {}
+        public DOPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public DOPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public DOPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "DO";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new DOPostalCode(code, allowConvertToShort);
+            return new DOPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/DZPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/DZPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class DZPostalCode : AlphaNumericPostalCode
     {
-        public DZPostalCode(string postalCode) : this(postalCode, true) {}
+        public DZPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public DZPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public DZPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "DZ";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new DZPostalCode(code, allowConvertToShort);
+            return new DZPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ECPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ECPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ECPostalCode : AlphaNumericPostalCode
     {
-        public ECPostalCode(string postalCode) : this(postalCode, true) {}
+        public ECPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ECPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ECPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "EC";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ECPostalCode(code, allowConvertToShort);
+            return new ECPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/EEPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/EEPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class EEPostalCode : AlphaNumericPostalCode
     {
-        public EEPostalCode(string postalCode) : this(postalCode, true) {}
+        public EEPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public EEPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public EEPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "EE";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new EEPostalCode(code, allowConvertToShort);
+            return new EEPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/EGPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/EGPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class EGPostalCode : AlphaNumericPostalCode
     {
-        public EGPostalCode(string postalCode) : this(postalCode, true) {}
+        public EGPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public EGPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public EGPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "EG";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new EGPostalCode(code, allowConvertToShort);
+            return new EGPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ESPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ESPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ESPostalCode : AlphaNumericPostalCode
     {
-        public ESPostalCode(string postalCode) : this(postalCode, true) {}
+        public ESPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ESPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ESPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "ES";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ESPostalCode(code, allowConvertToShort);
+            return new ESPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ETPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ETPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ETPostalCode : AlphaNumericPostalCode
     {
-        public ETPostalCode(string postalCode) : this(postalCode, true) {}
+        public ETPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ETPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ETPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "ET";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ETPostalCode(code, allowConvertToShort);
+            return new ETPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/FIPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/FIPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class FIPostalCode : AlphaNumericPostalCode
     {
-        public FIPostalCode(string postalCode) : this(postalCode, true) {}
+        public FIPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public FIPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public FIPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "FI";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new FIPostalCode(code, allowConvertToShort);
+            return new FIPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/FMPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/FMPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class FMPostalCode : AlphaNumericPostalCode
     {
-        public FMPostalCode(string postalCode) : this(postalCode, true) {}
+        public FMPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public FMPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public FMPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "FM";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new FMPostalCode(code, allowConvertToShort);
+            return new FMPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/FOPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/FOPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class FOPostalCode : AlphaNumericPostalCode
     {
-        public FOPostalCode(string postalCode) : this(postalCode, true) {}
+        public FOPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public FOPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public FOPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "FO";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new FOPostalCode(code, allowConvertToShort);
+            return new FOPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/FRPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/FRPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class FRPostalCode : AlphaNumericPostalCode
     {
-        public FRPostalCode(string postalCode) : this(postalCode, true) {}
+        public FRPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public FRPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public FRPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "FR";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new FRPostalCode(code, allowConvertToShort);
+            return new FRPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/GBPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/GBPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class GBPostalCode : AlphaNumericPostalCode
     {
-        public GBPostalCode(string postalCode) : this(postalCode, true) {}
+        public GBPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public GBPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public GBPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "Great Britain";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new GBPostalCode(code, allowConvertToShort);
+            return new GBPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/GEPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/GEPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class GEPostalCode : AlphaNumericPostalCode
     {
-        public GEPostalCode(string postalCode) : this(postalCode, true) {}
+        public GEPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public GEPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public GEPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "GE";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new GEPostalCode(code, allowConvertToShort);
+            return new GEPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/GLPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/GLPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class GLPostalCode : AlphaNumericPostalCode
     {
-        public GLPostalCode(string postalCode) : this(postalCode, true) {}
+        public GLPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public GLPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public GLPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "GL";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new GLPostalCode(code, allowConvertToShort);
+            return new GLPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/GRPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/GRPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class GRPostalCode : AlphaNumericPostalCode
     {
-        public GRPostalCode(string postalCode) : this(postalCode, true) {}
+        public GRPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public GRPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public GRPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "GR";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new GRPostalCode(code, allowConvertToShort);
+            return new GRPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/GTPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/GTPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class GTPostalCode : AlphaNumericPostalCode
     {
-        public GTPostalCode(string postalCode) : this(postalCode, true) {}
+        public GTPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public GTPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public GTPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "GT";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new GTPostalCode(code, allowConvertToShort);
+            return new GTPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/GUPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/GUPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class GUPostalCode : AlphaNumericPostalCode
     {
-        public GUPostalCode(string postalCode) : this(postalCode, true) {}
+        public GUPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public GUPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public GUPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "GU";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new GUPostalCode(code, allowConvertToShort);
+            return new GUPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/GWPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/GWPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class GWPostalCode : AlphaNumericPostalCode
     {
-        public GWPostalCode(string postalCode) : this(postalCode, true) {}
+        public GWPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public GWPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public GWPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "GW";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new GWPostalCode(code, allowConvertToShort);
+            return new GWPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/HMPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/HMPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class HMPostalCode : AlphaNumericPostalCode
     {
-        public HMPostalCode(string postalCode) : this(postalCode, true) {}
+        public HMPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public HMPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public HMPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "HM";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new HMPostalCode(code, allowConvertToShort);
+            return new HMPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/HNPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/HNPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class HNPostalCode : AlphaNumericPostalCode
     {
-        public HNPostalCode(string postalCode) : this(postalCode, true) {}
+        public HNPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public HNPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public HNPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "HN";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new HNPostalCode(code, allowConvertToShort);
+            return new HNPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/HRPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/HRPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class HRPostalCode : AlphaNumericPostalCode
     {
-        public HRPostalCode(string postalCode) : this(postalCode, true) {}
+        public HRPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public HRPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public HRPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "HR";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new HRPostalCode(code, allowConvertToShort);
+            return new HRPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/HTPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/HTPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class HTPostalCode : AlphaNumericPostalCode
     {
-        public HTPostalCode(string postalCode) : this(postalCode, true) {}
+        public HTPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public HTPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public HTPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "HT";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new HTPostalCode(code, allowConvertToShort);
+            return new HTPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/HUPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/HUPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class HUPostalCode : AlphaNumericPostalCode
     {
-        public HUPostalCode(string postalCode) : this(postalCode, true) {}
+        public HUPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public HUPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public HUPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "HU";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new HUPostalCode(code, allowConvertToShort);
+            return new HUPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/IDPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/IDPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class IDPostalCode : AlphaNumericPostalCode
     {
-        public IDPostalCode(string postalCode) : this(postalCode, true) {}
+        public IDPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public IDPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public IDPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "ID";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new IDPostalCode(code, allowConvertToShort);
+            return new IDPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ILPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ILPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ILPostalCode : AlphaNumericPostalCode
     {
-        public ILPostalCode(string postalCode) : this(postalCode, true) {}
+        public ILPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ILPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ILPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "IL";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ILPostalCode(code, allowConvertToShort);
+            return new ILPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/INPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/INPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class INPostalCode : AlphaNumericPostalCode
     {
-        public INPostalCode(string postalCode) : this(postalCode, true) {}
+        public INPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public INPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public INPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "IN";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new INPostalCode(code, allowConvertToShort);
+            return new INPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/IQPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/IQPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class IQPostalCode : AlphaNumericPostalCode
     {
-        public IQPostalCode(string postalCode) : this(postalCode, true) {}
+        public IQPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public IQPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public IQPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "IQ";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new IQPostalCode(code, allowConvertToShort);
+            return new IQPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ISPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ISPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ISPostalCode : AlphaNumericPostalCode
     {
-        public ISPostalCode(string postalCode) : this(postalCode, true) {}
+        public ISPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ISPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ISPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "IS";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ISPostalCode(code, allowConvertToShort);
+            return new ISPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ITPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ITPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ITPostalCode : AlphaNumericPostalCode
     {
-        public ITPostalCode(string postalCode) : this(postalCode, true) {}
+        public ITPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ITPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ITPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "IT";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ITPostalCode(code, allowConvertToShort);
+            return new ITPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/JOPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/JOPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class JOPostalCode : AlphaNumericPostalCode
     {
-        public JOPostalCode(string postalCode) : this(postalCode, true) {}
+        public JOPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public JOPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public JOPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "JO";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new JOPostalCode(code, allowConvertToShort);
+            return new JOPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/JPPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/JPPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class JPPostalCode : AlphaNumericPostalCode
     {
-        public JPPostalCode(string postalCode) : this(postalCode, true) {}
+        public JPPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public JPPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public JPPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "JP";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new JPPostalCode(code, allowConvertToShort);
+            return new JPPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/KEPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/KEPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class KEPostalCode : AlphaNumericPostalCode
     {
-        public KEPostalCode(string postalCode) : this(postalCode, true) {}
+        public KEPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public KEPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public KEPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "KE";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new KEPostalCode(code, allowConvertToShort);
+            return new KEPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/KGPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/KGPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class KGPostalCode : AlphaNumericPostalCode
     {
-        public KGPostalCode(string postalCode) : this(postalCode, true) {}
+        public KGPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public KGPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public KGPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "KG";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new KGPostalCode(code, allowConvertToShort);
+            return new KGPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/KHPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/KHPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class KHPostalCode : AlphaNumericPostalCode
     {
-        public KHPostalCode(string postalCode) : this(postalCode, true) {}
+        public KHPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public KHPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public KHPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "KH";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new KHPostalCode(code, allowConvertToShort);
+            return new KHPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/KWPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/KWPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class KWPostalCode : AlphaNumericPostalCode
     {
-        public KWPostalCode(string postalCode) : this(postalCode, true) {}
+        public KWPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public KWPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public KWPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "KW";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new KWPostalCode(code, allowConvertToShort);
+            return new KWPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/KZPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/KZPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class KZPostalCode : AlphaNumericPostalCode
     {
-        public KZPostalCode(string postalCode) : this(postalCode, true) {}
+        public KZPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public KZPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public KZPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "KZ";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new KZPostalCode(code, allowConvertToShort);
+            return new KZPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/LAPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/LAPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class LAPostalCode : AlphaNumericPostalCode
     {
-        public LAPostalCode(string postalCode) : this(postalCode, true) {}
+        public LAPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public LAPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public LAPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "LA";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new LAPostalCode(code, allowConvertToShort);
+            return new LAPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/LIPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/LIPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class LIPostalCode : AlphaNumericPostalCode
     {
-        public LIPostalCode(string postalCode) : this(postalCode, true) {}
+        public LIPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public LIPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public LIPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "LI";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new LIPostalCode(code, allowConvertToShort);
+            return new LIPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/LKPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/LKPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class LKPostalCode : AlphaNumericPostalCode
     {
-        public LKPostalCode(string postalCode) : this(postalCode, true) {}
+        public LKPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public LKPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public LKPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "LK";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new LKPostalCode(code, allowConvertToShort);
+            return new LKPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/LRPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/LRPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class LRPostalCode : AlphaNumericPostalCode
     {
-        public LRPostalCode(string postalCode) : this(postalCode, true) {}
+        public LRPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public LRPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public LRPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "LR";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new LRPostalCode(code, allowConvertToShort);
+            return new LRPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/LSPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/LSPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class LSPostalCode : AlphaNumericPostalCode
     {
-        public LSPostalCode(string postalCode) : this(postalCode, true) {}
+        public LSPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public LSPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public LSPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "LS";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new LSPostalCode(code, allowConvertToShort);
+            return new LSPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/LUPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/LUPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class LUPostalCode : AlphaNumericPostalCode
     {
-        public LUPostalCode(string postalCode) : this(postalCode, true) {}
+        public LUPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public LUPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public LUPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "LU";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new LUPostalCode(code, allowConvertToShort);
+            return new LUPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/LYPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/LYPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class LYPostalCode : AlphaNumericPostalCode
     {
-        public LYPostalCode(string postalCode) : this(postalCode, true) {}
+        public LYPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public LYPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public LYPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "LY";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new LYPostalCode(code, allowConvertToShort);
+            return new LYPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MAPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MAPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MAPostalCode : AlphaNumericPostalCode
     {
-        public MAPostalCode(string postalCode) : this(postalCode, true) {}
+        public MAPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MAPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MAPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MA";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MAPostalCode(code, allowConvertToShort);
+            return new MAPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MCPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MCPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MCPostalCode : AlphaNumericPostalCode
     {
-        public MCPostalCode(string postalCode) : this(postalCode, true) {}
+        public MCPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MCPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MCPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MC";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MCPostalCode(code, allowConvertToShort);
+            return new MCPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MEPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MEPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MEPostalCode : AlphaNumericPostalCode
     {
-        public MEPostalCode(string postalCode) : this(postalCode, true) {}
+        public MEPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MEPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MEPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "ME";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MEPostalCode(code, allowConvertToShort);
+            return new MEPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MGPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MGPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MGPostalCode : AlphaNumericPostalCode
     {
-        public MGPostalCode(string postalCode) : this(postalCode, true) {}
+        public MGPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MGPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MGPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MG";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MGPostalCode(code, allowConvertToShort);
+            return new MGPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MHPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MHPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MHPostalCode : AlphaNumericPostalCode
     {
-        public MHPostalCode(string postalCode) : this(postalCode, true) {}
+        public MHPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MHPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MHPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MH";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MHPostalCode(code, allowConvertToShort);
+            return new MHPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MKPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MKPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MKPostalCode : AlphaNumericPostalCode
     {
-        public MKPostalCode(string postalCode) : this(postalCode, true) {}
+        public MKPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MKPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MKPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MK";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MKPostalCode(code, allowConvertToShort);
+            return new MKPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MMPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MMPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MMPostalCode : AlphaNumericPostalCode
     {
-        public MMPostalCode(string postalCode) : this(postalCode, true) {}
+        public MMPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MMPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MMPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MM";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MMPostalCode(code, allowConvertToShort);
+            return new MMPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MNPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MNPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MNPostalCode : AlphaNumericPostalCode
     {
-        public MNPostalCode(string postalCode) : this(postalCode, true) {}
+        public MNPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MNPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MNPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MN";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MNPostalCode(code, allowConvertToShort);
+            return new MNPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MPPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MPPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MPPostalCode : AlphaNumericPostalCode
     {
-        public MPPostalCode(string postalCode) : this(postalCode, true) {}
+        public MPPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MPPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MPPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MP";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MPPostalCode(code, allowConvertToShort);
+            return new MPPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MQPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MQPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MQPostalCode : AlphaNumericPostalCode
     {
-        public MQPostalCode(string postalCode) : this(postalCode, true) {}
+        public MQPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MQPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MQPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MQ";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MQPostalCode(code, allowConvertToShort);
+            return new MQPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MTPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MTPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MTPostalCode : AlphaNumericPostalCode
     {
-        public MTPostalCode(string postalCode) : this(postalCode, true) {}
+        public MTPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MTPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MTPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "Malta";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MTPostalCode(code, allowConvertToShort);
+            return new MTPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MUPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MUPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MUPostalCode : AlphaNumericPostalCode
     {
-        public MUPostalCode(string postalCode) : this(postalCode, true) {}
+        public MUPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MUPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MUPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MU";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MUPostalCode(code, allowConvertToShort);
+            return new MUPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MXPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MXPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MXPostalCode : AlphaNumericPostalCode
     {
-        public MXPostalCode(string postalCode) : this(postalCode, true) {}
+        public MXPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MXPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MXPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MX";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MXPostalCode(code, allowConvertToShort);
+            return new MXPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MYPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MYPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MYPostalCode : AlphaNumericPostalCode
     {
-        public MYPostalCode(string postalCode) : this(postalCode, true) {}
+        public MYPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MYPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MYPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MY";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MYPostalCode(code, allowConvertToShort);
+            return new MYPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/MZPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/MZPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class MZPostalCode : AlphaNumericPostalCode
     {
-        public MZPostalCode(string postalCode) : this(postalCode, true) {}
+        public MZPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public MZPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public MZPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "MZ";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new MZPostalCode(code, allowConvertToShort);
+            return new MZPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/NAPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/NAPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class NAPostalCode : AlphaNumericPostalCode
     {
-        public NAPostalCode(string postalCode) : this(postalCode, true) {}
+        public NAPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public NAPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public NAPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "NA";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new NAPostalCode(code, allowConvertToShort);
+            return new NAPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/NEPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/NEPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class NEPostalCode : AlphaNumericPostalCode
     {
-        public NEPostalCode(string postalCode) : this(postalCode, true) {}
+        public NEPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public NEPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public NEPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "NE";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new NEPostalCode(code, allowConvertToShort);
+            return new NEPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/NFPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/NFPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class NFPostalCode : AlphaNumericPostalCode
     {
-        public NFPostalCode(string postalCode) : this(postalCode, true) {}
+        public NFPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public NFPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public NFPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "NF";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new NFPostalCode(code, allowConvertToShort);
+            return new NFPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/NGPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/NGPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class NGPostalCode : AlphaNumericPostalCode
     {
-        public NGPostalCode(string postalCode) : this(postalCode, true) {}
+        public NGPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public NGPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public NGPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "NG";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new NGPostalCode(code, allowConvertToShort);
+            return new NGPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/NIPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/NIPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class NIPostalCode : AlphaNumericPostalCode
     {
-        public NIPostalCode(string postalCode) : this(postalCode, true) {}
+        public NIPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public NIPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public NIPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "NI";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new NIPostalCode(code, allowConvertToShort);
+            return new NIPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/NLPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/NLPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class NLPostalCode : AlphaNumericPostalCode
     {
-        public NLPostalCode(string postalCode) : this(postalCode, true) {}
+        public NLPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public NLPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public NLPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "Netherlands";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new NLPostalCode(code, allowConvertToShort);
+            return new NLPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/NOPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/NOPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class NOPostalCode : AlphaNumericPostalCode
     {
-        public NOPostalCode(string postalCode) : this(postalCode, true) {}
+        public NOPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public NOPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public NOPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "NO";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new NOPostalCode(code, allowConvertToShort);
+            return new NOPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/NPPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/NPPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class NPPostalCode : AlphaNumericPostalCode
     {
-        public NPPostalCode(string postalCode) : this(postalCode, true) {}
+        public NPPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public NPPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public NPPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "NP";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new NPPostalCode(code, allowConvertToShort);
+            return new NPPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/NZPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/NZPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class NZPostalCode : AlphaNumericPostalCode
     {
-        public NZPostalCode(string postalCode) : this(postalCode, true) {}
+        public NZPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public NZPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public NZPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "NZ";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new NZPostalCode(code, allowConvertToShort);
+            return new NZPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/OMPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/OMPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class OMPostalCode : AlphaNumericPostalCode
     {
-        public OMPostalCode(string postalCode) : this(postalCode, true) {}
+        public OMPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public OMPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public OMPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "OM";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new OMPostalCode(code, allowConvertToShort);
+            return new OMPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PAPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PAPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class PAPostalCode : AlphaNumericPostalCode
     {
-        public PAPostalCode(string postalCode) : this(postalCode, true) {}
+        public PAPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public PAPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public PAPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "PA";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new PAPostalCode(code, allowConvertToShort);
+            return new PAPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PEPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PEPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class PEPostalCode : AlphaNumericPostalCode
     {
-        public PEPostalCode(string postalCode) : this(postalCode, true) {}
+        public PEPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public PEPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public PEPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "PE";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new PEPostalCode(code, allowConvertToShort);
+            return new PEPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PGPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PGPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class PGPostalCode : AlphaNumericPostalCode
     {
-        public PGPostalCode(string postalCode) : this(postalCode, true) {}
+        public PGPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public PGPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public PGPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "PG";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new PGPostalCode(code, allowConvertToShort);
+            return new PGPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PHPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PHPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class PHPostalCode : AlphaNumericPostalCode
     {
-        public PHPostalCode(string postalCode) : this(postalCode, true) {}
+        public PHPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public PHPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public PHPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "PH";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new PHPostalCode(code, allowConvertToShort);
+            return new PHPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PKPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PKPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class PKPostalCode : AlphaNumericPostalCode
     {
-        public PKPostalCode(string postalCode) : this(postalCode, true) {}
+        public PKPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public PKPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public PKPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "PK";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new PKPostalCode(code, allowConvertToShort);
+            return new PKPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PLPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PLPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class PLPostalCode : AlphaNumericPostalCode
     {
-        public PLPostalCode(string postalCode) : this(postalCode, true) {}
+        public PLPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public PLPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public PLPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "Poland";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new PLPostalCode(code, allowConvertToShort);
+            return new PLPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PRPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PRPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class PRPostalCode : AlphaNumericPostalCode
     {
-        public PRPostalCode(string postalCode) : this(postalCode, true) {}
+        public PRPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public PRPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public PRPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "PR";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new PRPostalCode(code, allowConvertToShort);
+            return new PRPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PSPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PSPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class PSPostalCode : AlphaNumericPostalCode
     {
-        public PSPostalCode(string postalCode) : this(postalCode, true) {}
+        public PSPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public PSPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public PSPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "PS";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new PSPostalCode(code, allowConvertToShort);
+            return new PSPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PTPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PTPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class PTPostalCode : AlphaNumericPostalCode
     {
-        public PTPostalCode(string postalCode) : this(postalCode, true) {}
+        public PTPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public PTPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public PTPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "Portugal";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new PTPostalCode(code, allowConvertToShort);
+            return new PTPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PWPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PWPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class PWPostalCode : AlphaNumericPostalCode
     {
-        public PWPostalCode(string postalCode) : this(postalCode, true) {}
+        public PWPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public PWPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public PWPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "PW";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new PWPostalCode(code, allowConvertToShort);
+            return new PWPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PYPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/PYPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class PYPostalCode : AlphaNumericPostalCode
     {
-        public PYPostalCode(string postalCode) : this(postalCode, true) {}
+        public PYPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public PYPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public PYPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "PY";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new PYPostalCode(code, allowConvertToShort);
+            return new PYPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/PostalCodeFactory.gen.tt
+++ b/src/PostalCodes/Generated/PostalCodeFactory.gen.tt
@@ -124,7 +124,7 @@ namespace PostalCodes
 	public class CountryInfo {
 		public string CountryCodeAlpha2 { get; set; }
 		public string CountryName { get; set; }
-		public string WhiteSpaceCharacters { get; set; }
+		public string RedundantCharacters { get; set; }
 
 		public List<Dictionary<string, string>> Formats { get; set; }
 
@@ -169,16 +169,16 @@ namespace PostalCodes
 {
     internal partial class <#= countryInfo.CountryCodeAlpha2 #>PostalCode : AlphaNumericPostalCode
     {
-        public <#= countryInfo.CountryCodeAlpha2 #>PostalCode(string postalCode) : this(postalCode, true) {}
+        public <#= countryInfo.CountryCodeAlpha2 #>PostalCode(string postalCode) : this(postalCode, "<#= countryInfo.RedundantCharacters #>", true) {}
 
-        public <#= countryInfo.CountryCodeAlpha2 #>PostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public <#= countryInfo.CountryCodeAlpha2 #>PostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "<#= countryInfo.CountryName #>";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new <#= countryInfo.CountryCodeAlpha2 #>PostalCode(code, allowConvertToShort);
+            return new <#= countryInfo.CountryCodeAlpha2 #>PostalCode(code, "<#= countryInfo.RedundantCharacters #>", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ROPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ROPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ROPostalCode : AlphaNumericPostalCode
     {
-        public ROPostalCode(string postalCode) : this(postalCode, true) {}
+        public ROPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ROPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ROPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "RO";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ROPostalCode(code, allowConvertToShort);
+            return new ROPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/RSPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/RSPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class RSPostalCode : AlphaNumericPostalCode
     {
-        public RSPostalCode(string postalCode) : this(postalCode, true) {}
+        public RSPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public RSPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public RSPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "RS";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new RSPostalCode(code, allowConvertToShort);
+            return new RSPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/RUPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/RUPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class RUPostalCode : AlphaNumericPostalCode
     {
-        public RUPostalCode(string postalCode) : this(postalCode, true) {}
+        public RUPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public RUPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public RUPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "RU";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new RUPostalCode(code, allowConvertToShort);
+            return new RUPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/SDPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/SDPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class SDPostalCode : AlphaNumericPostalCode
     {
-        public SDPostalCode(string postalCode) : this(postalCode, true) {}
+        public SDPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public SDPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public SDPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "SD";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new SDPostalCode(code, allowConvertToShort);
+            return new SDPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/SEPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/SEPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class SEPostalCode : AlphaNumericPostalCode
     {
-        public SEPostalCode(string postalCode) : this(postalCode, true) {}
+        public SEPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public SEPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public SEPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "SE";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new SEPostalCode(code, allowConvertToShort);
+            return new SEPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/SGPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/SGPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class SGPostalCode : AlphaNumericPostalCode
     {
-        public SGPostalCode(string postalCode) : this(postalCode, true) {}
+        public SGPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public SGPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public SGPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "SG";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new SGPostalCode(code, allowConvertToShort);
+            return new SGPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/SIPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/SIPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class SIPostalCode : AlphaNumericPostalCode
     {
-        public SIPostalCode(string postalCode) : this(postalCode, true) {}
+        public SIPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public SIPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public SIPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "SI";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new SIPostalCode(code, allowConvertToShort);
+            return new SIPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/SJPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/SJPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class SJPostalCode : AlphaNumericPostalCode
     {
-        public SJPostalCode(string postalCode) : this(postalCode, true) {}
+        public SJPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public SJPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public SJPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "SJ";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new SJPostalCode(code, allowConvertToShort);
+            return new SJPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/SKPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/SKPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class SKPostalCode : AlphaNumericPostalCode
     {
-        public SKPostalCode(string postalCode) : this(postalCode, true) {}
+        public SKPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public SKPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public SKPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "SK";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new SKPostalCode(code, allowConvertToShort);
+            return new SKPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/SNPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/SNPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class SNPostalCode : AlphaNumericPostalCode
     {
-        public SNPostalCode(string postalCode) : this(postalCode, true) {}
+        public SNPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public SNPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public SNPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "SN";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new SNPostalCode(code, allowConvertToShort);
+            return new SNPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/TDPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/TDPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class TDPostalCode : AlphaNumericPostalCode
     {
-        public TDPostalCode(string postalCode) : this(postalCode, true) {}
+        public TDPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public TDPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public TDPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "TD";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new TDPostalCode(code, allowConvertToShort);
+            return new TDPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/THPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/THPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class THPostalCode : AlphaNumericPostalCode
     {
-        public THPostalCode(string postalCode) : this(postalCode, true) {}
+        public THPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public THPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public THPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "TH";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new THPostalCode(code, allowConvertToShort);
+            return new THPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/TJPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/TJPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class TJPostalCode : AlphaNumericPostalCode
     {
-        public TJPostalCode(string postalCode) : this(postalCode, true) {}
+        public TJPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public TJPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public TJPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "TJ";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new TJPostalCode(code, allowConvertToShort);
+            return new TJPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/TMPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/TMPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class TMPostalCode : AlphaNumericPostalCode
     {
-        public TMPostalCode(string postalCode) : this(postalCode, true) {}
+        public TMPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public TMPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public TMPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "TM";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new TMPostalCode(code, allowConvertToShort);
+            return new TMPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/TNPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/TNPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class TNPostalCode : AlphaNumericPostalCode
     {
-        public TNPostalCode(string postalCode) : this(postalCode, true) {}
+        public TNPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public TNPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public TNPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "TN";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new TNPostalCode(code, allowConvertToShort);
+            return new TNPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/TRPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/TRPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class TRPostalCode : AlphaNumericPostalCode
     {
-        public TRPostalCode(string postalCode) : this(postalCode, true) {}
+        public TRPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public TRPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public TRPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "TR";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new TRPostalCode(code, allowConvertToShort);
+            return new TRPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/TTPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/TTPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class TTPostalCode : AlphaNumericPostalCode
     {
-        public TTPostalCode(string postalCode) : this(postalCode, true) {}
+        public TTPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public TTPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public TTPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "TT";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new TTPostalCode(code, allowConvertToShort);
+            return new TTPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/TWPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/TWPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class TWPostalCode : AlphaNumericPostalCode
     {
-        public TWPostalCode(string postalCode) : this(postalCode, true) {}
+        public TWPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public TWPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public TWPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "TW";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new TWPostalCode(code, allowConvertToShort);
+            return new TWPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/UAPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/UAPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class UAPostalCode : AlphaNumericPostalCode
     {
-        public UAPostalCode(string postalCode) : this(postalCode, true) {}
+        public UAPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public UAPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public UAPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "UA";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new UAPostalCode(code, allowConvertToShort);
+            return new UAPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/USPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/USPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class USPostalCode : AlphaNumericPostalCode
     {
-        public USPostalCode(string postalCode) : this(postalCode, true) {}
+        public USPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public USPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public USPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "US";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new USPostalCode(code, allowConvertToShort);
+            return new USPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/UYPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/UYPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class UYPostalCode : AlphaNumericPostalCode
     {
-        public UYPostalCode(string postalCode) : this(postalCode, true) {}
+        public UYPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public UYPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public UYPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "UY";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new UYPostalCode(code, allowConvertToShort);
+            return new UYPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/VIPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/VIPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class VIPostalCode : AlphaNumericPostalCode
     {
-        public VIPostalCode(string postalCode) : this(postalCode, true) {}
+        public VIPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public VIPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public VIPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "VI";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new VIPostalCode(code, allowConvertToShort);
+            return new VIPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/VNPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/VNPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class VNPostalCode : AlphaNumericPostalCode
     {
-        public VNPostalCode(string postalCode) : this(postalCode, true) {}
+        public VNPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public VNPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public VNPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "VN";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new VNPostalCode(code, allowConvertToShort);
+            return new VNPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/XKPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/XKPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class XKPostalCode : AlphaNumericPostalCode
     {
-        public XKPostalCode(string postalCode) : this(postalCode, true) {}
+        public XKPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public XKPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public XKPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "XK";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new XKPostalCode(code, allowConvertToShort);
+            return new XKPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/YTPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/YTPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class YTPostalCode : AlphaNumericPostalCode
     {
-        public YTPostalCode(string postalCode) : this(postalCode, true) {}
+        public YTPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public YTPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public YTPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "YT";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new YTPostalCode(code, allowConvertToShort);
+            return new YTPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ZAPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ZAPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ZAPostalCode : AlphaNumericPostalCode
     {
-        public ZAPostalCode(string postalCode) : this(postalCode, true) {}
+        public ZAPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ZAPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ZAPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "ZA";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ZAPostalCode(code, allowConvertToShort);
+            return new ZAPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/Generated/ZMPostalCode.gen.cs
+++ b/src/PostalCodes/Generated/ZMPostalCode.gen.cs
@@ -5,16 +5,16 @@ namespace PostalCodes
 {
     internal partial class ZMPostalCode : AlphaNumericPostalCode
     {
-        public ZMPostalCode(string postalCode) : this(postalCode, true) {}
+        public ZMPostalCode(string postalCode) : this(postalCode, " -", true) {}
 
-        public ZMPostalCode(string postalCode, bool allowConvertToShort) : base(_formats, postalCode, allowConvertToShort) 
+        public ZMPostalCode(string postalCode, string redundantCharacters, bool allowConvertToShort) : base(_formats, redundantCharacters, postalCode, allowConvertToShort) 
         {
             _countryName = "ZM";
         }
         
         protected override PostalCode CreatePostalCode(string code, bool allowConvertToShort)
         {
-            return new ZMPostalCode(code, allowConvertToShort);
+            return new ZMPostalCode(code, " -", allowConvertToShort);
         }
         
         public override bool Equals (object obj)

--- a/src/PostalCodes/GenericPostalCodes/AlphaNumericPostalCode.cs
+++ b/src/PostalCodes/GenericPostalCodes/AlphaNumericPostalCode.cs
@@ -2,8 +2,8 @@
 {
     internal abstract class AlphaNumericPostalCode : PostalCode
     {
-        internal AlphaNumericPostalCode(PostalCodeFormat[] formats, string postalCode, bool allowConvertToShort)
-            : base(formats, postalCode, allowConvertToShort) {}
+        internal AlphaNumericPostalCode(PostalCodeFormat[] formats, string redundantCharacters, string postalCode, bool allowConvertToShort)
+			: base(formats, redundantCharacters, postalCode, allowConvertToShort) {}
 
         /// <summary>
         /// Gets the internal value.

--- a/src/PostalCodes/GenericPostalCodes/DefaultPostalCode.cs
+++ b/src/PostalCodes/GenericPostalCodes/DefaultPostalCode.cs
@@ -6,12 +6,12 @@ namespace PostalCodes.GenericPostalCodes
     {
 
         public DefaultPostalCode(string postalCode)
-            : base(_formats, postalCode, true)
+            : base(_formats, " -", postalCode, true)
         {
         }
 
         public DefaultPostalCode(string postalCode, bool allowConvertToShort)
-            : base(_formats, postalCode, allowConvertToShort)
+            : base(_formats, " -", postalCode, allowConvertToShort)
         {
         }
 

--- a/src/PostalCodes/PostalCode.cs
+++ b/src/PostalCodes/PostalCode.cs
@@ -51,7 +51,7 @@ namespace PostalCodes
         /// <summary>
         /// The white space characters.
         /// </summary>
-        protected string _whiteSpaceCharacters = " -";
+        protected string _redundantCharacters = " -";
 
         /// <summary>
         /// The name of the country.
@@ -67,9 +67,10 @@ namespace PostalCodes
         /// Initializes a new instance of the <see cref="PostalCodes.PostalCode"/> class.
         /// </summary>
         /// <param name="formats">Formats.</param>
+		/// <param name="redundantCharacters">Characters that are considered insignificant for the meaning of the postal code</param>
         /// <param name="postalCode">Postal code.</param>
-        internal PostalCode(PostalCodeFormat[] formats, string postalCode)
-            : this(formats, postalCode, true) 
+		internal PostalCode(PostalCodeFormat[] formats, string redundantCharacters, string postalCode)
+			: this(formats, redundantCharacters, postalCode, true) 
         {
         }
 
@@ -77,11 +78,13 @@ namespace PostalCodes
         /// Initializes a new instance of the <see cref="PostalCodes.PostalCode"/> class.
         /// </summary>
         /// <param name="formats">Formats.</param>
+		/// <param name="redundantCharacters">Characters that are considered insignificant for the meaning of the postal code</param>
         /// <param name="postalCode">Postal code.</param>
         /// <param name="allowConvertToShort">If set to <c>true</c> allow convert to short format.</param>
-        internal PostalCode(PostalCodeFormat[] formats, string postalCode, bool allowConvertToShort)
+		internal PostalCode(PostalCodeFormat[] formats, string redundantCharacters, string postalCode, bool allowConvertToShort)
         {
             _allowConvertToShort = allowConvertToShort;
+			_redundantCharacters = redundantCharacters;
 
             var nonWhiteSpaceCode = ClearWhiteSpaces (postalCode);
 
@@ -463,7 +466,7 @@ namespace PostalCodes
         protected string ClearWhiteSpaces(string code)
         {
             var normalized = code;
-            foreach (var c in _whiteSpaceCharacters.ToCharArray())
+            foreach (var c in _redundantCharacters.ToCharArray())
             {
                 normalized = normalized.Replace (c + "", "");
             }

--- a/src/PostalCodes/PostalCodes.csproj
+++ b/src/PostalCodes/PostalCodes.csproj
@@ -51,6 +51,45 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>PostalCodeFactory.gen.cs</LastGenOutput>
     </None>
+    <None Include="..\countries\3Digits.json">
+      <Link>PostalCodeDefinitions\3Digits.json</Link>
+    </None>
+    <None Include="..\countries\4Digits.json">
+      <Link>PostalCodeDefinitions\4Digits.json</Link>
+    </None>
+    <None Include="..\countries\5Digits.json">
+      <Link>PostalCodeDefinitions\5Digits.json</Link>
+    </None>
+    <None Include="..\countries\6Digits.json">
+      <Link>PostalCodeDefinitions\6Digits.json</Link>
+    </None>
+    <None Include="..\countries\7Digits.json">
+      <Link>PostalCodeDefinitions\7Digits.json</Link>
+    </None>
+    <None Include="..\countries\BB.json">
+      <Link>PostalCodeDefinitions\BB.json</Link>
+    </None>
+    <None Include="..\countries\CA.json">
+      <Link>PostalCodeDefinitions\CA.json</Link>
+    </None>
+    <None Include="..\countries\GB.json">
+      <Link>PostalCodeDefinitions\GB.json</Link>
+    </None>
+    <None Include="..\countries\MT.json">
+      <Link>PostalCodeDefinitions\MT.json</Link>
+    </None>
+    <None Include="..\countries\NL.json">
+      <Link>PostalCodeDefinitions\NL.json</Link>
+    </None>
+    <None Include="..\countries\PL.json">
+      <Link>PostalCodeDefinitions\PL.json</Link>
+    </None>
+    <None Include="..\countries\PT.json">
+      <Link>PostalCodeDefinitions\PT.json</Link>
+    </None>
+    <None Include="..\countries\RU.json">
+      <Link>PostalCodeDefinitions\RU.json</Link>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Country.cs" />
@@ -80,6 +119,7 @@
     <Folder Include="GenericPostalCodes\" />
     <Folder Include="Extensions\" />
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+    <Folder Include="PostalCodeDefinitions\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="BeforeBuild">

--- a/src/countries/3Digits.json
+++ b/src/countries/3Digits.json
@@ -2,7 +2,7 @@
 	"CountryName" : "N/A",
 	"CountryCodeAlpha2" : "N/A",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{

--- a/src/countries/4Digits.json
+++ b/src/countries/4Digits.json
@@ -2,7 +2,7 @@
 	"CountryName" : "N/A",
 	"CountryCodeAlpha2" : "N/A",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{

--- a/src/countries/5Digits.json
+++ b/src/countries/5Digits.json
@@ -2,7 +2,7 @@
 	"CountryName" : "N/A",
 	"CountryCodeAlpha2" : "N/A",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{

--- a/src/countries/6Digits.json
+++ b/src/countries/6Digits.json
@@ -2,7 +2,7 @@
 	"CountryName" : "N/A",
 	"CountryCodeAlpha2" : "N/A",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{

--- a/src/countries/7Digits.json
+++ b/src/countries/7Digits.json
@@ -2,7 +2,7 @@
 	"CountryName" : "N/A",
 	"CountryCodeAlpha2" : "N/A",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{

--- a/src/countries/BB.json
+++ b/src/countries/BB.json
@@ -2,7 +2,7 @@
 	"CountryName" : "Barbados",
 	"CountryCodeAlpha2" : "BB",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{

--- a/src/countries/CA.json
+++ b/src/countries/CA.json
@@ -2,7 +2,7 @@
 	"CountryName" : "Canada",
 	"CountryCodeAlpha2" : "CA",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{

--- a/src/countries/GB.json
+++ b/src/countries/GB.json
@@ -2,7 +2,7 @@
 	"CountryName" : "Great Britain",
 	"CountryCodeAlpha2" : "GB",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{

--- a/src/countries/MT.json
+++ b/src/countries/MT.json
@@ -2,7 +2,7 @@
 	"CountryName" : "Malta",
 	"CountryCodeAlpha2" : "MT",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{

--- a/src/countries/NL.json
+++ b/src/countries/NL.json
@@ -2,7 +2,7 @@
 	"CountryName" : "Netherlands",
 	"CountryCodeAlpha2" : "NL",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{

--- a/src/countries/PL.json
+++ b/src/countries/PL.json
@@ -1,7 +1,7 @@
 {
 	"CountryName" : "Poland",
 	"CountryCodeAlpha2" : "PL",
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 	"Formats" : [
 			{
 				"Name" : "PL : 99-999",

--- a/src/countries/PT.json
+++ b/src/countries/PT.json
@@ -2,7 +2,7 @@
 	"CountryName" : "Portugal",
 	"CountryCodeAlpha2" : "PT",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{

--- a/src/countries/RU.json
+++ b/src/countries/RU.json
@@ -2,7 +2,7 @@
 	"CountryName" : "Russia",
 	"CountryCodeAlpha2" : "RU",
 
-	"WhiteSpaceCharacters" : " -",
+	"RedundantCharacters" : " -",
 
 	"Formats" : [
 			{


### PR DESCRIPTION
To resolve the issue #22 providing changes that allow the redundant characters to be configured per postalcode