### PR TITLE
Provide debugging symbols

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ deploy:
 - provider: NuGet
   api_key:
     secure: DK9YLl9zwAwoGGPvu+Sf25PN9lLuiIUJgJ/hXXfJiTUNr5FVSIDuio5/Ncl2suLY
-  skip_symbols: true
+  skip_symbols: false
   artifact: NuGet
   on:
     branch: /release/.*/

--- a/src/PostalCodes/PostalCodes.csproj
+++ b/src/PostalCodes/PostalCodes.csproj
@@ -127,6 +127,6 @@
     <Exec WorkingDirectory="$(SolutionDir)" Condition=" '$(OS)' != 'Unix' " Command=".nuget\NuGet.exe restore" />
   </Target>
   <Target Name="AfterBuild">
-    <Exec WorkingDirectory="$(TargetDir)" Condition=" '$(OS)' != 'Unix' " Command="$(SolutionDir).nuget\NuGet.exe pack $(ProjectPath)" />
+    <Exec WorkingDirectory="$(TargetDir)" Condition=" '$(OS)' != 'Unix' " Command="$(SolutionDir).nuget\NuGet.exe pack -symbols $(ProjectPath)" />
   </Target>
 </Project>


### PR DESCRIPTION
For issue #50 this seems to be all is needed. 

The change in cspoj file will cause generation of both main and symbol nu get package, and the appveryor should start uploading it to the symbol server (nuget.gw.symbolsource.org/Public/NuGet)

See [this](http://www.symbolsource.org/Public/Wiki/Publishing) and [this](http://www.symbolsource.org/Public/Wiki/Using) for more details. 

